### PR TITLE
ProxyDirContext Hook & readFile ext regex Filter

### DIFF
--- a/agent/java/src/main/java/com/fuxi/javaagent/config/Config.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/config/Config.java
@@ -63,6 +63,7 @@ public class Config {
             + "java.lang.Runtime.exec,"
             + "java.lang.ProcessBuilder.start";
     private static final String DEFAULT_LOG_STACK_SIZE = "20";
+    private static final String DEFAULT_READ_FILE_EXTENSION_REGEX = "^(gz|7z|xz|tar|rar|zip|sql|db)$";
 
     private static final Logger LOGGER = Logger.getLogger(Config.class.getName());
     private static String baseDirectory;
@@ -76,6 +77,7 @@ public class Config {
     private boolean enforcePolicy;
     private String[] reflectionMonitorMethod;
     private int logMaxStackSize;
+    private String readFileExtensionRegex;
 
     private String blockUrl;
 
@@ -113,6 +115,7 @@ public class Config {
         this.reflectionMaxStack = Integer.parseInt(DEFAULT_REFLECTION_MAX_STACK);
         this.logMaxStackSize = Integer.parseInt(DEFAULT_LOG_STACK_SIZE);
         this.blockUrl = DEFAULT_BLOCK_URL;
+        this.readFileExtensionRegex = DEFAULT_READ_FILE_EXTENSION_REGEX;
 
         try {
             input = new FileInputStream(new File(baseDirectory, "conf" + File.separator + "rasp.properties"));
@@ -128,6 +131,7 @@ public class Config {
             this.reflectionMaxStack = Integer.parseInt(properties.getProperty("reflection.maxstack", DEFAULT_REFLECTION_MAX_STACK));
             this.logMaxStackSize = Integer.parseInt(properties.getProperty("log.maxstack", DEFAULT_LOG_STACK_SIZE));
             this.blockUrl = properties.getProperty("block.url", DEFAULT_BLOCK_URL);
+            this.readFileExtensionRegex = properties.getProperty("readfile.extension.regex", DEFAULT_READ_FILE_EXTENSION_REGEX);
         } catch (FileNotFoundException e) {
             LOGGER.warn("Could not find rasp.properties, using default settings: " + e.getMessage());
         } catch (IOException e) {
@@ -154,6 +158,7 @@ public class Config {
         LOGGER.info("reflection.monitor: " + Arrays.toString(this.reflectionMonitorMethod));
         LOGGER.info("reflection.maxstack: " + reflectionMaxStack);
         LOGGER.info("block.url: " + blockUrl);
+        LOGGER.info("readfile.extension.regex: " + readFileExtensionRegex);
     }
 
     private static class ConfigHolder {
@@ -296,4 +301,21 @@ public class Config {
         this.blockUrl = blockUrl;
     }
 
+    /**
+     * 获取读文件需要检测的扩展名正则表达式
+     *
+     * @return
+     */
+    public synchronized String getReadFileExtensionRegex() {
+        return readFileExtensionRegex;
+    }
+
+    /**
+     * 设置读文件需要检测的扩展名正则表达式
+     *
+     * @param readFileExtensionRegex
+     */
+    public synchronized void setReadFileExtensionRegex(String readFileExtensionRegex) {
+        this.readFileExtensionRegex = readFileExtensionRegex;
+    }
 }

--- a/agent/java/src/main/java/com/fuxi/javaagent/hook/ProxyDirContextHook.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/hook/ProxyDirContextHook.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2017 Baidu, Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.fuxi.javaagent.hook;
+
+import com.fuxi.javaagent.HookHandler;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.AdviceAdapter;
+import org.objectweb.asm.commons.Method;
+
+/**
+ * Created by zhuming01 on 5/31/17.
+ * All rights reserved
+ */
+public class ProxyDirContextHook extends AbstractClassHook {
+    /**
+     * (none-javadoc)
+     *
+     * @see AbstractClassHook#getType()
+     */
+    @Override
+    public String getType() {
+        return "readFile";
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "org/apache/naming/resources/ProxyDirContext".equals(className);
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see AbstractClassHook#hookMethod(int, String, String, String, String[], MethodVisitor)
+     */
+    @Override
+    protected MethodVisitor hookMethod(int access, String name, String desc, String signature, String[] exceptions, MethodVisitor mv) {
+        if ("lookup".equals(name) && desc.startsWith("(Ljava/lang/String;)")) {
+            return new AdviceAdapter(Opcodes.ASM5, mv, access, name, desc) {
+                @Override
+                public void onMethodExit(int opcode) {
+                    if (opcode == Opcodes.ARETURN) {
+                        mv.visitVarInsn(ALOAD, 2);
+                        mv.visitMethodInsn(INVOKESTATIC, "com/fuxi/javaagent/HookHandler", "checkResourceCacheEntry",
+                                "(Ljava/lang/Object;)V", false);
+                    }
+                    super.onMethodExit(opcode);
+                }
+
+            };
+        }
+        return mv;
+    }
+}

--- a/agent/java/src/main/java/com/fuxi/javaagent/plugin/JSContextFactory.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/plugin/JSContextFactory.java
@@ -96,6 +96,7 @@ public class JSContextFactory extends ContextFactory {
 
             RASP = (ScriptableObject) ScriptableObject.getProperty(globalScope, "RASP");
             RASP.defineProperty("sql_tokenize", new JSTokenizeSql(), ScriptableObject.READONLY);
+            RASP.defineProperty("set_read_file_ext_regex", new JSReadFileExtRegex(), ScriptableObject.READONLY);
         } finally {
             Context.exit();
         }

--- a/agent/java/src/main/java/com/fuxi/javaagent/plugin/JSReadFileExtRegex.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/plugin/JSReadFileExtRegex.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2017 Baidu, Inc. All Rights Reserved.
+ * <p>
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * <p>
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * <p>
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * <p>
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.fuxi.javaagent.plugin;
+
+import com.fuxi.javaagent.config.Config;
+import org.mozilla.javascript.BaseFunction;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+/**
+ * 修改需检测的读文件扩展名正则表达式
+ */
+public class JSReadFileExtRegex extends BaseFunction {
+    /**
+     * @see BaseFunction#call(Context, Scriptable, Scriptable, Object[])
+     * @param cx
+     * @param scope
+     * @param thisObj
+     * @param args
+     * @return
+     */
+    @Override
+    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+                       Object[] args) {
+        if (args.length < 1) {
+            return Context.getUndefinedValue();
+        }
+        if (!(args[0] instanceof String)) {
+            return Context.getUndefinedValue();
+        }
+        String regex = (String) args[0];
+        Config.getConfig().setReadFileExtensionRegex(regex);
+        Scriptable result = cx.newObject(scope);
+        return result;
+    }
+
+    /**
+     * 提供获取该对象默认值的方法
+     * console.log(thisObj) 即会输出此方法返回的值
+     * @see Scriptable#getDefaultValue(Class)
+     * @param hint
+     * @return
+     */
+    @Override
+    public Object getDefaultValue(Class<?> hint) {
+        return "[Function: set_read_file_ext_regex]";
+    }
+}

--- a/agent/java/src/main/java/com/fuxi/javaagent/transformer/CustomClassTransformer.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/transformer/CustomClassTransformer.java
@@ -73,6 +73,7 @@ public class CustomClassTransformer implements ClassFileTransformer {
         addHook(new JettyHttpInputHook());
         addHook(new JettyServerHook());
         addHook(new CoyoteAdapterHook());
+        addHook(new ProxyDirContextHook());
     }
 
     private void addHook(AbstractClassHook hook) {


### PR DESCRIPTION
增加ProxyDirContext Hook点
增加readFile 对文件扩展名进行匹配的正则表达式配置项：readfile.extension.regex  
（默认值：^(gz|7z|xz|tar|rar|zip|sql|db)$
    可在rasp.properties中进行修改）
为插件提供修改改配置项的接口：RASP.set_read_file_ext_regex(your_custom_regex)