### PR TITLE
在 HookHandler 里构造插件使用的 JS 对像

### DIFF
--- a/agent/java/src/main/java/com/fuxi/javaagent/Agent.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/Agent.java
@@ -67,9 +67,9 @@ public class Agent {
                 return;
             }
             readVersion();
-            initTransformer(inst);
             // 初始化插件系统
             PluginManager.init();
+            initTransformer(inst);
             String message = "OpenRasp Initialized [" + projectVersion + " (build: GitCommit=" + gitCommit + " date="
                     + buildTime + ")]";
             System.out.println(message);

--- a/agent/java/src/main/java/com/fuxi/javaagent/HookHandler.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/HookHandler.java
@@ -35,16 +35,22 @@ import com.fuxi.javaagent.exception.SecurityException;
 import com.fuxi.javaagent.hook.SQLStatementHook;
 import com.fuxi.javaagent.hook.XXEHook;
 import com.fuxi.javaagent.plugin.CheckParameter;
+import com.fuxi.javaagent.plugin.JSContext;
+import com.fuxi.javaagent.plugin.JSContextFactory;
 import com.fuxi.javaagent.plugin.PluginManager;
 import com.fuxi.javaagent.request.AbstractRequest;
 import com.fuxi.javaagent.request.HttpServletRequest;
 import com.fuxi.javaagent.response.HttpServletResponse;
-import com.fuxi.javaagent.tool.*;
+import com.fuxi.javaagent.tool.FileUtil;
+import com.fuxi.javaagent.tool.Reflection;
+import com.fuxi.javaagent.tool.StackTrace;
+import com.fuxi.javaagent.tool.TimeUtils;
 import com.fuxi.javaagent.tool.hook.CustomLockObject;
 import com.fuxi.javaagent.tool.security.SqlConnectionChecker;
 import com.fuxi.javaagent.tool.security.TomcatSecurityChecker;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.log4j.Logger;
+import org.mozilla.javascript.Scriptable;
 
 import java.io.File;
 import java.io.IOException;
@@ -130,16 +136,17 @@ public class HookHandler {
      */
     public static void checkFileUpload(String name, byte[] content) {
         if (name != null && content != null) {
-            Map<String, Object> params = new HashMap<String, Object>();
-            params.put("filename", name);
+            JSContext cx = JSContextFactory.enterAndInitContext();
+            Scriptable params = cx.newObject(cx.getScope());
+            params.put("filename", params, name);
             try {
                 if (content.length > 4 * 1024) {
                     content = Arrays.copyOf(content, 4 * 1024);
                 }
-                params.put("content", new String(content, "UTF-8"));
+                params.put("content", params, new String(content, "UTF-8"));
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();
-                params.put("content", "[rasp error:" + e.getMessage() + "]");
+                params.put("content", params, "[rasp error:" + e.getMessage() + "]");
             }
 
             doCheck(CheckParameter.Type.FILEUPLOAD, params);
@@ -153,12 +160,13 @@ public class HookHandler {
      */
     public static void checkListFiles(File file) {
         if (file != null) {
-            Map<String, Object> params = new HashMap<String, Object>();
-            params.put("path", file.getPath());
+            JSContext cx = JSContextFactory.enterAndInitContext();
+            Scriptable params = cx.newObject(cx.getScope());
+            params.put("path", params, file.getPath());
             try {
-                params.put("realpath", file.getCanonicalPath());
+                params.put("realpath", params, file.getCanonicalPath());
             } catch (IOException e) {
-                params.put("realpath", file.getAbsolutePath());
+                params.put("realpath", params, file.getAbsolutePath());
             }
 
             doCheck(CheckParameter.Type.DIRECTORY, params);
@@ -189,13 +197,14 @@ public class HookHandler {
      */
     public static void checkSQL(String server, Object statement, String stmt) {
         if (stmt != null && !stmt.isEmpty()) {
-            Map<String, Object> params = new HashMap<String, Object>();
+            JSContext cx = JSContextFactory.enterAndInitContext();
+            Scriptable params = cx.newObject(cx.getScope());
             String connectionId = SQLStatementHook.getSqlConnectionId(server, statement);
             if (connectionId != null) {
-                params.put(server + "_connection_id", connectionId);
+                params.put(server + "_connection_id", params, connectionId);
             }
-            params.put("server", server);
-            params.put("query", stmt);
+            params.put("server", params, server);
+            params.put("query", params, stmt);
 
             doCheck(CheckParameter.Type.SQL, params);
         }
@@ -220,7 +229,7 @@ public class HookHandler {
             responseCache.set(responseContainer);
 
             XXEHook.resetLocalExpandedSystemIds();
-            doCheck(CheckParameter.Type.REQUEST, EMPTY_MAP);
+            doCheck(CheckParameter.Type.REQUEST, JSContext.getUndefinedValue());
 
         }
     }
@@ -259,19 +268,20 @@ public class HookHandler {
      */
     public static void checkReadFile(File file) {
         if (file != null) {
-            HashMap<String, Object> param = new HashMap<String, Object>();
-            param.put("path", file.getPath());
+            JSContext cx = JSContextFactory.enterAndInitContext();
+            Scriptable params = cx.newObject(cx.getScope());
+            params.put("path", params, file.getPath());
             try {
                 String path = file.getCanonicalPath();
                 if (path.endsWith(".class") || !file.exists()) {
                     return;
                 }
-                param.put("realpath", FileUtil.getRealPath(file));
+                params.put("realpath", params, FileUtil.getRealPath(file));
             } catch (IOException e) {
                 e.printStackTrace();
             }
 
-            doCheck(CheckParameter.Type.READFILE, param);
+            doCheck(CheckParameter.Type.READFILE, params);
         }
     }
 
@@ -282,9 +292,11 @@ public class HookHandler {
      */
     public static void checkCommand(List<String> command) {
         if (command != null && !command.isEmpty()) {
-            HashMap<String, Object> param = new HashMap<String, Object>();
-            param.put("command", command);
-            doCheck(CheckParameter.Type.COMMAND, param);
+            JSContext cx = JSContextFactory.enterAndInitContext();
+            Scriptable params = cx.newObject(cx.getScope());
+            Scriptable array = cx.newArray(cx.getScope(), command.toArray());
+            params.put("command", params, array);
+            doCheck(CheckParameter.Type.COMMAND, params);
         }
     }
 
@@ -296,9 +308,10 @@ public class HookHandler {
     public static void checkXXE(String expandedSystemId) {
         if (expandedSystemId != null && !XXEHook.getLocalExpandedSystemIds().contains(expandedSystemId)) {
             XXEHook.getLocalExpandedSystemIds().add(expandedSystemId);
-            HashMap<String, Object> param = new HashMap<String, Object>();
-            param.put("entity", expandedSystemId);
-            doCheck(CheckParameter.Type.XXE, param);
+            JSContext cx = JSContextFactory.enterAndInitContext();
+            Scriptable params = cx.newObject(cx.getScope());
+            params.put("entity", params, expandedSystemId);
+            doCheck(CheckParameter.Type.XXE, params);
         }
     }
 
@@ -309,11 +322,12 @@ public class HookHandler {
      */
     public static void checkWriteFile(File file) {
         if (file != null) {
-            HashMap<String, Object> param = new HashMap<String, Object>();
-            param.put("name", file.getName());
-            param.put("realpath", FileUtil.getRealPath(file));
-            param.put("content", "");
-            doCheck(CheckParameter.Type.WRITEFILE, param);
+            JSContext cx = JSContextFactory.enterAndInitContext();
+            Scriptable params = cx.newObject(cx.getScope());
+            params.put("name", params, file.getName());
+            params.put("realpath", params, FileUtil.getRealPath(file));
+            params.put("content", params, "");
+            doCheck(CheckParameter.Type.WRITEFILE, params);
         }
     }
 
@@ -328,10 +342,11 @@ public class HookHandler {
             String path = ((CustomLockObject) closeLock).getInfo();
             if (path != null && writeBytes != null && writeBytes.length > 0) {
                 File file = new File(path);
-                Map<String, Object> params = new HashMap<String, Object>();
-                params.put("name", file.getName());
-                params.put("realpath", path);
-                params.put("content", new String(writeBytes));
+                JSContext cx = JSContextFactory.enterAndInitContext();
+                Scriptable params = cx.newObject(cx.getScope());
+                params.put("name", params, file.getName());
+                params.put("realpath", params, path);
+                params.put("content", params, new String(writeBytes));
                 doCheck(CheckParameter.Type.WRITEFILE, params);
             }
         }
@@ -356,8 +371,9 @@ public class HookHandler {
      */
     public static void checkOgnlExpression(String expression) {
         if (expression != null) {
-            Map<String, Object> params = new HashMap<String, Object>();
-            params.put("expression", expression);
+            JSContext cx = JSContextFactory.enterAndInitContext();
+            Scriptable params = cx.newObject(cx.getScope());
+            params.put("expression", params, expression);
             doCheck(CheckParameter.Type.OGNL, params);
         }
     }
@@ -371,8 +387,9 @@ public class HookHandler {
         if (objectStreamClass != null) {
             String clazz = objectStreamClass.getName();
             if (clazz != null) {
-                Map<String, Object> params = new HashMap<String, Object>();
-                params.put("clazz", clazz);
+                JSContext cx = JSContextFactory.enterAndInitContext();
+                Scriptable params = cx.newObject(cx.getScope());
+                params.put("clazz", params, clazz);
                 doCheck(CheckParameter.Type.DESERIALIZATION, params);
             }
         }
@@ -408,12 +425,13 @@ public class HookHandler {
                 String[] reflectMonitorMethod = Config.getConfig().getReflectionMonitorMethod();
                 for (String monitorMethod : reflectMonitorMethod) {
                     if (monitorMethod.equals(absoluteMethodName)) {
-                        Map<String, Object> params = new HashMap<String, Object>();
+                        JSContext cx = JSContextFactory.enterAndInitContext();
+                        Scriptable params = cx.newObject(cx.getScope());
                         List<String> stackInfo = StackTrace.getStackTraceArray(Config.REFLECTION_STACK_START_INDEX,
                                 Config.getConfig().getReflectionMaxStack());
-                        params.put("clazz", reflectClassName);
-                        params.put("method", reflectMethodName);
-                        params.put("stack", stackInfo);
+                        params.put("clazz", params, reflectClassName);
+                        params.put("method", params, reflectMethodName);
+                        params.put("stack", params, stackInfo);
                         pluginCheck(CheckParameter.Type.REFLECTION, params);
                         break;
                     }
@@ -442,10 +460,11 @@ public class HookHandler {
                 e.printStackTrace();
             }
             if (realPath != null) {
-                HashMap<String, Object> param = new HashMap<String, Object>();
-                param.put("source", realPath + source);
-                param.put("dest", realPath + dest);
-                doCheck(CheckParameter.Type.WEBDAV, param);
+                JSContext cx = JSContextFactory.enterAndInitContext();
+                Scriptable params = cx.newObject(cx.getScope());
+                params.put("source", params, realPath + source);
+                params.put("dest", params, realPath + dest);
+                doCheck(CheckParameter.Type.WEBDAV, params);
             }
         }
     }
@@ -541,14 +560,14 @@ public class HookHandler {
      * @param type   检测类型
      * @param params 检测参数map，key为参数名，value为检测参数值
      */
-    private static void doCheck(CheckParameter.Type type, Map<String, Object> params) {
+    private static void doCheck(CheckParameter.Type type, Object params) {
         if (enableHook.get() && enableCurrThreadHook.get()) {
             enableCurrThreadHook.set(false);
             pluginCheck(type, params);
         }
     }
 
-    private static void pluginCheck(CheckParameter.Type type, Map<String, Object> params) {
+    private static void pluginCheck(CheckParameter.Type type, Object params) {
         CheckParameter parameter = new CheckParameter(type, params, requestCache.get());
         boolean isBlock = false;
         try {

--- a/agent/java/src/main/java/com/fuxi/javaagent/plugin/CheckParameter.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/plugin/CheckParameter.java
@@ -68,12 +68,12 @@ public class CheckParameter {
     }
 
     private final Type type;
-    private final Map<String, Object> params;
+    private final Object params;
     private final AbstractRequest request;
     private final long createTime;
 
 
-    public CheckParameter(Type type, Map<String, Object> params, AbstractRequest request) {
+    public CheckParameter(Type type, Object params, AbstractRequest request) {
         this.type = type;
         this.params = params;
         this.request = request;
@@ -84,7 +84,7 @@ public class CheckParameter {
         return type;
     }
 
-    public Map<String, Object> getParams() {
+    public Object getParams() {
         return params;
     }
 

--- a/agent/java/src/main/java/com/fuxi/javaagent/plugin/JSContext.java
+++ b/agent/java/src/main/java/com/fuxi/javaagent/plugin/JSContext.java
@@ -30,13 +30,12 @@
 
 package com.fuxi.javaagent.plugin;
 
-import com.fuxi.javaagent.plugin.event.AttackInfo;
 import com.fuxi.javaagent.config.Config;
+import com.fuxi.javaagent.plugin.event.AttackInfo;
 import org.apache.log4j.Logger;
 import org.mozilla.javascript.*;
 
 import java.util.List;
-import java.util.Map;
 
 public class JSContext extends Context {
     private static final Logger LOGGER = Logger.getLogger(JSContext.class.getPackage().getName() + ".log");
@@ -94,18 +93,8 @@ public class JSContext extends Context {
         if (processList.size() < 1) {
             return false;
         }
-        Map<String, Object> parameterParams = parameter.getParams();
-        Scriptable params = newObject(scope);
-        for (Map.Entry<String, Object> param : parameterParams.entrySet()) {
-            Object value = param.getValue();
-            if (value instanceof String) {
-                params.put(param.getKey(), params, value);
-            } else if (value instanceof List) {
-                Scriptable array = newArray(scope, ((List) value).toArray());
-                params.put(param.getKey(), params, array);
-            }
-        }
 
+        Scriptable params = (Scriptable) parameter.getParams();
         Scriptable requestContext = this.newObject(scope, "Context", new Object[]{parameter.getRequest()});
 
         Object[] functionArgs = {params, requestContext};


### PR DESCRIPTION
原先是在 HookHandler 里构造 Map 对象，然后在之后的逻辑里转换为 JS 对象

现在 HookHandler 里直接构造插件使用的 JS 对像，避免了多余的创建和遍历 Map 对象的过程
