### PR TITLE
fix(travis) update the filename of the installer

### DIFF
--- a/integration-test/start-jboss4.sh
+++ b/integration-test/start-jboss4.sh
@@ -16,9 +16,9 @@ cp app.war ${SERVER_HOME}/server/default/deploy/
 
 # export JAVA_OPTS="-javaagent:${SERVER_HOME}/rasp/rasp.jar -Dlog4j.rasp.configuration=file://${SERVER_HOME}/rasp/conf/rasp-log4j.xml ${JAVA_OPTS}"
 
-wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*linux" | cut -d '"' -f 4)
+wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*rasp-any\.tar\.gz" | cut -d '"' -f 4)
 
-tar zxf rasp-linux-64bit.tar.gz --strip-components=1  $(tar ztf rasp-linux-64bit.tar.gz --wildcards "*RaspInstall.jar")
+tar zxf rasp-any.tar.gz --strip-components=1  $(tar ztf rasp-any.tar.gz --wildcards "*RaspInstall.jar")
 
 java -jar RaspInstall.jar ${SERVER_HOME}
 

--- a/integration-test/start-jboss5.sh
+++ b/integration-test/start-jboss5.sh
@@ -18,9 +18,9 @@ cp app.war ${SERVER_HOME}/server/default/deploy/
 
 # export JAVA_OPTS="-javaagent:${SERVER_HOME}/rasp/rasp.jar -Dlog4j.rasp.configuration=file://${SERVER_HOME}/rasp/conf/rasp-log4j.xml ${JAVA_OPTS}"
 
-wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*linux" | cut -d '"' -f 4)
+wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*rasp-any\.tar\.gz" | cut -d '"' -f 4)
 
-tar zxf rasp-linux-64bit.tar.gz --strip-components=1  $(tar ztf rasp-linux-64bit.tar.gz --wildcards "*RaspInstall.jar")
+tar zxf rasp-any.tar.gz --strip-components=1  $(tar ztf rasp-any.tar.gz --wildcards "*RaspInstall.jar")
 
 java -jar RaspInstall.jar ${SERVER_HOME}
 

--- a/integration-test/start-jboss6.sh
+++ b/integration-test/start-jboss6.sh
@@ -18,9 +18,9 @@ cp app.war ${SERVER_HOME}/server/default/deploy/
 
 # export JAVA_OPTS="-javaagent:${SERVER_HOME}/rasp/rasp.jar -Dlog4j.rasp.configuration=file://${SERVER_HOME}/rasp/conf/rasp-log4j.xml ${JAVA_OPTS}"
 
-wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*linux" | cut -d '"' -f 4)
+wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*rasp-any\.tar\.gz" | cut -d '"' -f 4)
 
-tar zxf rasp-linux-64bit.tar.gz --strip-components=1  $(tar ztf rasp-linux-64bit.tar.gz --wildcards "*RaspInstall.jar")
+tar zxf rasp-any.tar.gz --strip-components=1  $(tar ztf rasp-any.tar.gz --wildcards "*RaspInstall.jar")
 
 java -jar RaspInstall.jar ${SERVER_HOME}
 

--- a/integration-test/start-tomcat6.sh
+++ b/integration-test/start-tomcat6.sh
@@ -16,9 +16,9 @@ cp app.war ${SERVER_HOME}/webapps/
 
 # export JAVA_OPTS="-javaagent:${SERVER_HOME}/rasp/rasp.jar -Dlog4j.rasp.configuration=file://${SERVER_HOME}/rasp/conf/rasp-log4j.xml ${JAVA_OPTS}"
 
-wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*linux" | cut -d '"' -f 4)
+wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*rasp-any\.tar\.gz" | cut -d '"' -f 4)
 
-tar zxf rasp-linux-64bit.tar.gz --strip-components=1  $(tar ztf rasp-linux-64bit.tar.gz --wildcards "*RaspInstall.jar")
+tar zxf rasp-any.tar.gz --strip-components=1  $(tar ztf rasp-any.tar.gz --wildcards "*RaspInstall.jar")
 
 java -jar RaspInstall.jar ${SERVER_HOME}
 

--- a/integration-test/start-tomcat7.sh
+++ b/integration-test/start-tomcat7.sh
@@ -16,9 +16,9 @@ cp app.war ${SERVER_HOME}/webapps/
 
 # export JAVA_OPTS="-javaagent:${SERVER_HOME}/rasp/rasp.jar -Dlog4j.rasp.configuration=file://${SERVER_HOME}/rasp/conf/rasp-log4j.xml ${JAVA_OPTS}"
 
-wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*linux" | cut -d '"' -f 4)
+wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*rasp-any\.tar\.gz" | cut -d '"' -f 4)
 
-tar zxf rasp-linux-64bit.tar.gz --strip-components=1  $(tar ztf rasp-linux-64bit.tar.gz --wildcards "*RaspInstall.jar")
+tar zxf rasp-any.tar.gz --strip-components=1  $(tar ztf rasp-any.tar.gz --wildcards "*RaspInstall.jar")
 
 java -jar RaspInstall.jar ${SERVER_HOME}
 

--- a/integration-test/start-tomcat8.sh
+++ b/integration-test/start-tomcat8.sh
@@ -16,9 +16,9 @@ cp app.war ${SERVER_HOME}/webapps/
 
 # export JAVA_OPTS="-javaagent:${SERVER_HOME}/rasp/rasp.jar -Dlog4j.rasp.configuration=file://${SERVER_HOME}/rasp/conf/rasp-log4j.xml ${JAVA_OPTS}"
 
-wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*linux" | cut -d '"' -f 4)
+wget -N $(curl -s https://api.github.com/repos/baidu/openrasp/releases/latest | grep "browser_download_url.*rasp-any\.tar\.gz" | cut -d '"' -f 4)
 
-tar zxf rasp-linux-64bit.tar.gz --strip-components=1  $(tar ztf rasp-linux-64bit.tar.gz --wildcards "*RaspInstall.jar")
+tar zxf rasp-any.tar.gz --strip-components=1  $(tar ztf rasp-any.tar.gz --wildcards "*RaspInstall.jar")
 
 java -jar RaspInstall.jar ${SERVER_HOME}
 


### PR DESCRIPTION
由于最新 release 的安装包名字更新了，travis 测试中找不到对应安装包，导致测试失败