### PR TITLE
OpenRasp支持Tongweb 6.1代码提交

### DIFF
--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetector.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetector.java
@@ -108,6 +108,8 @@ public abstract class ServerDetector {
             HookHandler.doRealCheckWithoutRequest(CheckParameter.Type.POLICY_SERVER_WILDFLY, CheckParameter.EMPTY_MAP);
         } else if ("jboss eap".equals(serverName)) {
             HookHandler.doRealCheckWithoutRequest(CheckParameter.Type.POLICY_SERVER_JBOSSEAP, CheckParameter.EMPTY_MAP);
+        } else if ("tongweb".equals(serverName)) {
+            HookHandler.doRealCheckWithoutRequest(CheckParameter.Type.POLICY_SERVER_TONGWEB, CheckParameter.EMPTY_MAP);
         }
     }
 

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetectorManager.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetectorManager.java
@@ -43,6 +43,7 @@ public class ServerDetectorManager {
         detectors.add(new WebsphereDetector());
         detectors.add(new UndertowDetector());
         detectors.add(new DubboDetector());
+        detectors.add(new TongWebDetector());
     }
 
     public static ServerDetectorManager getInstance() {

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/TongWebDetector.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/TongWebDetector.java
@@ -1,0 +1,40 @@
+/**
+ * 
+ */
+package com.baidu.openrasp.detector;
+
+import com.baidu.openrasp.tool.Reflection;
+import com.baidu.openrasp.tool.model.ApplicationModel;
+
+import java.lang.reflect.Method;
+import java.security.ProtectionDomain;
+
+/**
+ * @author baimo
+ *
+ */
+public class TongWebDetector extends ServerDetector {
+
+	@Override
+	public boolean isClassMatched(String className) {
+        return "com/tongweb/web/thor/Server".equals(className);
+	}
+
+	@Override
+	public boolean handleServerInfo(ClassLoader classLoader, ProtectionDomain domain) {
+        String version = "";
+        try {
+            if (classLoader == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            }
+            Class clazz = classLoader.loadClass("com.tongweb.web.thor.util.ServerInfo");
+            version = (String) Reflection.invokeMethod(null, clazz, "getServerNumber", new Class[]{});
+            ApplicationModel.setServerInfo("tongweb", version);
+            return true;
+        } catch (Throwable t) {
+            logDetectError("handle Tongweb startup failed", t);
+        }
+        return false;
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebFilterHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebFilterHook.java
@@ -1,0 +1,42 @@
+package com.baidu.openrasp.hook.server.tongweb;
+
+import java.io.IOException;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import com.baidu.openrasp.hook.server.ServerRequestHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+
+/**
+ * @description: Tongweb ApplicationFilterChain 处理hook
+ * @author: Baimo
+ * @create: 2019/06/10
+ */
+@HookAnnotation
+public class TongwebFilterHook extends ServerRequestHook {
+
+	/**
+	 * (none-javadoc)
+	 *
+	 * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+	 */
+	@Override
+	public boolean isClassMatched(String className) {
+		return className.endsWith("com/tongweb/web/thor/core/ApplicationFilterChain");
+	}
+
+	/**
+	 * (none-javadoc)
+	 *
+	 * @see com.baidu.openrasp.hook.AbstractClassHook#hookMethod(CtClass)
+	 */
+	@Override
+	protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+		String src = getInvokeStaticSrc(ServerRequestHook.class, "checkRequest", "$0,$1,$2", Object.class, Object.class,
+				Object.class);
+		insertBefore(ctClass, "doFilter", null, src);
+	}
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebHttpResponseHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebHttpResponseHook.java
@@ -1,0 +1,34 @@
+package com.baidu.openrasp.hook.server.tongweb;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import com.baidu.openrasp.hook.server.ServerOutputCloseHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+
+/**
+ * @description: 插入Tongweb服务器应答处理hook
+ * @author: Baimo
+ * @create: 2019/06/10
+ */
+@HookAnnotation
+public class TongwebHttpResponseHook extends ServerOutputCloseHook {
+
+    public static String clazzName = null;
+
+	@Override
+	public boolean isClassMatched(String className) {
+        if ("com/tongweb/web/thor/connector/Response".equals(className)) {
+            clazzName = className;
+            return true;
+        }
+        return false;	
+    }
+    
+	@Override
+	protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "finishResponse", "()V", src);
+	}
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebInputBufferHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebInputBufferHook.java
@@ -1,0 +1,53 @@
+package com.baidu.openrasp.hook.server.tongweb;
+
+import java.io.IOException;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import com.baidu.openrasp.HookHandler;
+import com.baidu.openrasp.hook.server.ServerInputHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+
+/**
+ * @description: 插入Tongweb获取请求body处理hook
+ * @author: Baimo
+ * @create: 2019/06/11
+ */
+@HookAnnotation
+public class TongwebInputBufferHook extends ServerInputHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/tongweb/web/thor/connector/InputBuffer".equals(className);
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#hookMethod(CtClass)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String readByteSrc = getInvokeStaticSrc(HookHandler.class, "onInputStreamRead",
+                "$_,$0", int.class, Object.class);
+        insertAfter(ctClass, "readByte", "()I", readByteSrc);        
+        String readSrc = getInvokeStaticSrc(HookHandler.class, "onInputStreamRead",
+                "$_,$0,$1,$2,$3", int.class, Object.class, byte[].class, int.class, int.class);
+        insertAfter(ctClass, "read", "([BII)I", readSrc);
+        //
+//        String readCharSrc1 = getInvokeStaticSrc(HookHandler.class, "onInputStreamRead",
+//                "$_,$0", int.class, Object.class);
+        insertAfter(ctClass, "read", "()I", "\nSystem.out.println(\"======= InputBuffer.read()I ========\");");        
+
+//        String readCharSrc2 = getInvokeStaticSrc(HookHandler.class, "onInputStreamRead",
+//                "$_,$0,$1,$2,$3", int.class, Object.class, char[].class, int.class, int.class);
+        insertAfter(ctClass, "read", "([CII)I", "\nSystem.out.println(\"======= InputBuffer.read([CII)I ========\");");        
+    }
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebInputBufferHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebInputBufferHook.java
@@ -40,14 +40,6 @@ public class TongwebInputBufferHook extends ServerInputHook {
         insertAfter(ctClass, "readByte", "()I", readByteSrc);        
         String readSrc = getInvokeStaticSrc(HookHandler.class, "onInputStreamRead",
                 "$_,$0,$1,$2,$3", int.class, Object.class, byte[].class, int.class, int.class);
-        insertAfter(ctClass, "read", "([BII)I", readSrc);
-        //
-//        String readCharSrc1 = getInvokeStaticSrc(HookHandler.class, "onInputStreamRead",
-//                "$_,$0", int.class, Object.class);
-        insertAfter(ctClass, "read", "()I", "\nSystem.out.println(\"======= InputBuffer.read()I ========\");");        
-
-//        String readCharSrc2 = getInvokeStaticSrc(HookHandler.class, "onInputStreamRead",
-//                "$_,$0,$1,$2,$3", int.class, Object.class, char[].class, int.class, int.class);
-        insertAfter(ctClass, "read", "([CII)I", "\nSystem.out.println(\"======= InputBuffer.read([CII)I ========\");");        
+        insertAfter(ctClass, "read", "([BII)I", readSrc);       
     }
 }

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebPreRequestHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebPreRequestHook.java
@@ -1,0 +1,38 @@
+package com.baidu.openrasp.hook.server.tongweb;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import com.baidu.openrasp.hook.server.ServerPreRequestHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+
+/**
+ * @description: Tongweb ServerPreRequestHook 处理hook，会执行onParseParameters 进行预处理
+ * @author: Baimo
+ * @create: 2019/06/18
+ */
+@HookAnnotation
+public class TongwebPreRequestHook extends ServerPreRequestHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("com/tongweb/web/thor/connector/CoyoteAdapter");
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.server.ServerPreRequestHook#hookMethod(CtClass, String)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "service", null, src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebRequestHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebRequestHook.java
@@ -1,0 +1,33 @@
+package com.baidu.openrasp.hook.server.tongweb;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import com.baidu.openrasp.hook.server.ServerParamHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+
+/**
+ * @description: 插入Tongweb获取request请求处理hook
+ * @author: Baimo
+ * @create: 2019/06/11
+ */
+@HookAnnotation
+public class TongwebRequestHook extends ServerParamHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/tongweb/web/thor/connector/Request".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "parseParameters", "()V", src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebRequestHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebRequestHook.java
@@ -22,12 +22,12 @@ public class TongwebRequestHook extends ServerParamHook {
      */
     @Override
     public boolean isClassMatched(String className) {
-        return "com/tongweb/web/thor/connector/Request".equals(className);
+        return "com/tongweb/web/oro/Request".equals(className);
     }
 
     @Override
     protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
-        insertBefore(ctClass, "parseParameters", "()V", src);
+        insertBefore(ctClass, "getParameters", null, src);
     }
 
 }

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebXssHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb/TongwebXssHook.java
@@ -1,0 +1,63 @@
+/**
+ * 
+ */
+package com.baidu.openrasp.hook.server.tongweb;
+
+import com.baidu.openrasp.HookHandler;
+import com.baidu.openrasp.cloud.model.ErrorType;
+import com.baidu.openrasp.cloud.utils.CloudUtils;
+import com.baidu.openrasp.hook.server.ServerXssHook;
+import com.baidu.openrasp.plugin.checker.CheckParameter;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import com.baidu.openrasp.tool.model.ApplicationModel;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+/**
+ * @description: Tongweb body_xss hook点
+ * @author: Baimo
+ * @create: 2019/06/19
+ */
+@HookAnnotation
+public class TongwebXssHook extends ServerXssHook {
+
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/tongweb/web/thor/connector/OutputBuffer".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String src1 = getInvokeStaticSrc(TongwebXssHook.class, "getBufferFromByteArray", "$1,$2,$3", byte[].class, int.class, int.class);
+        insertBefore(ctClass, "realWriteBytes", "([BII)V", src1);
+    }
+
+    public static void getBufferFromByteArray(byte[] buf, int off, int cnt) {
+        if (HookHandler.isEnableXssHook()) {
+            HookHandler.disableBodyXssHook();
+            HashMap<String, Object> params = new HashMap<String, Object>();
+            if (buf != null && cnt > 0) {
+                try {
+                    byte[] temp = new byte[cnt + 1];
+                    System.arraycopy(buf, off, temp, 0, cnt);
+                    String content = new String(temp);
+                    params.put("html_body", content);
+
+                } catch (Exception e) {
+                    String message = ApplicationModel.getServerName() + " xss detectde failed";
+                    int errorCode = ErrorType.HOOK_ERROR.getCode();
+                    HookHandler.LOGGER.warn(CloudUtils.getExceptionObject(message, errorCode), e);
+                }
+                if (HookHandler.requestCache.get() != null && !params.isEmpty()) {
+                    HookHandler.doCheck(CheckParameter.Type.XSS_USERINPUT, params);
+                }
+            }
+        }
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/CheckParameter.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/CheckParameter.java
@@ -69,7 +69,8 @@ public class CheckParameter {
         POLICY_SERVER_RESIN("resinServer", new ResinSecurityChecker(false), 0),
         POLICY_SERVER_WEBSPHERE("websphereServer", new WebsphereSecurityChecker(false), 0),
         POLICY_SERVER_WEBLOGIC("weblogicServer", new WeblogicSecurityChecker(false), 0),
-        POLICY_SERVER_WILDFLY("wildflyServer", new WildflySecurityChecker(false), 0);
+        POLICY_SERVER_WILDFLY("wildflyServer", new WildflySecurityChecker(false), 0),
+        POLICY_SERVER_TONGWEB("tongwebServer", new TongwebSecurityChecker(false), 0);
 
         String name;
         Checker checker;

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/policy/server/TongwebSecurityChecker.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/policy/server/TongwebSecurityChecker.java
@@ -1,0 +1,24 @@
+package com.baidu.openrasp.plugin.checker.policy.server;
+
+import java.util.List;
+
+import com.baidu.openrasp.plugin.checker.CheckParameter;
+import com.baidu.openrasp.plugin.info.EventInfo;
+
+public class TongwebSecurityChecker extends ServerPolicyChecker {
+
+    public TongwebSecurityChecker() {
+        super();
+    }
+
+    public TongwebSecurityChecker(boolean canBlock) {
+        super(canBlock);
+    }
+    
+	@Override
+	public void checkServer(CheckParameter checkParameter, List<EventInfo> infos) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/request/HttpServletRequest.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/request/HttpServletRequest.java
@@ -186,7 +186,7 @@ public final class HttpServletRequest extends AbstractRequest {
     @Override
     public Map<String, String[]> getParameterMap() {
         Map<String, String[]> normalMap = new HashMap<String, String[]>();
-        if (ApplicationModel.getServerName().equals("undertow") || ApplicationModel.getServerName().equals("tongweb") || canGetParameter) {
+        if (ApplicationModel.getServerName().equals("undertow") || canGetParameter) {
             normalMap = (Map<String, String[]>) Reflection.invokeMethod(request, "getParameterMap", EMPTY_CLASS);
         } else {
             if (!setCharacterEncodingFromConfig()) {

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/request/HttpServletRequest.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/request/HttpServletRequest.java
@@ -186,7 +186,7 @@ public final class HttpServletRequest extends AbstractRequest {
     @Override
     public Map<String, String[]> getParameterMap() {
         Map<String, String[]> normalMap = new HashMap<String, String[]>();
-        if (ApplicationModel.getServerName().equals("undertow") || canGetParameter) {
+        if (ApplicationModel.getServerName().equals("undertow") || ApplicationModel.getServerName().equals("tongweb") || canGetParameter) {
             normalMap = (Map<String, String[]>) Reflection.invokeMethod(request, "getParameterMap", EMPTY_CLASS);
         } else {
             if (!setCharacterEncodingFromConfig()) {


### PR DESCRIPTION
提交说明：基于openrasp当前master版本，提交了支持Tongweb服务器的代码，新增8个java文件，修改4个java文件。

测试结果：针对vulns测试用例，除005、006测试用例不支持，017在ie中仍然存在问题（1.0也有同样问题），其他测试用例均已测试通过。测试环境：CentOS 6.4 / 1.7.0_65（64位) / Tongweb  6.1  ，rasp以单机模式运行（管理平台未测试）。

遗留说明：RaspInstall.jar 尚不支持在tongweb上安装rasp，这块代码未进行改造。