### PR TITLE
fix ssrf and xxe bypass

### DIFF
--- a/plugins/official/plugin.js
+++ b/plugins/official/plugin.js
@@ -1346,7 +1346,7 @@ if (! algorithmConfig.meta.is_dev && RASP.get_jsengine() !== 'v8') {
         {
             if (is_from_userinput(parameter, url))
             {
-                if (ip.length && /^(127|10|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\./.test(ip[0]))
+                if (ip.length && /^(0|127|10|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\./.test(ip[0]))
                 {
                     return {
                         action:     algorithmConfig.ssrf_userinput.action,
@@ -1384,7 +1384,8 @@ if (! algorithmConfig.meta.is_dev && RASP.get_jsengine() !== 'v8') {
         // 算法3 - 检测 AWS/Aliyun/GoogleCloud 私有地址
         if (algorithmConfig.ssrf_aws.action != 'ignore')
         {
-            if (hostname == '169.254.169.254' || hostname == '100.100.100.200' || hostname == 'metadata.google.internal')
+            if (ip == '169.254.169.254' || ip == '100.100.100.200'
+                || hostname == '169.254.169.254' || hostname == '100.100.100.200' || hostname == 'metadata.google.internal')
             {
                 return {
                     action:     algorithmConfig.ssrf_aws.action,
@@ -2086,7 +2087,7 @@ plugin.register('xxe', function (params, context) {
     }
 
     if (items.length >= 2) {
-        var protocol = items[0]
+        var protocol = items[0].toLowerCase()
         var address  = items[1]
 
         // 拒绝特殊协议
@@ -2112,10 +2113,10 @@ plugin.register('xxe', function (params, context) {
             if (address.length > 0 && protocol === 'file' && is_absolute_path(address, is_win) )
             {
                 var address_lc = address.toLowerCase()
-
+                var urlObj = new URL(address_lc)
                 // 过滤掉 xml、dtd
-                if (! address_lc.endsWith('.xml') &&
-                    ! address_lc.endsWith('.dtd'))
+                if (! urlObj.pathname.endsWith('.xml') &&
+                    ! urlObj.pathname.endsWith('.dtd'))
                 {
                     return {
                         action:     algorithmConfig.xxe_file.action,


### PR DESCRIPTION
[中文说明: 提交你的代码](https://rasp.baidu.com/doc/hacking/pull-request.html)

XXE插件
问题：
1. 敏感协议过滤可以通过大写绕过
2. 为了减少误报，插件放过后缀名为xml和dtd的链接。可以利用这个特性来绕过检测，例如file:///etc/passwd#.xml

SSRF插件
问题：
1. IP黑名单中少了0.0.0.0
2. 插件禁用了hostname为100.100.100.200（阿里云元数据接口），169.254.169.254（AWS元数据接口），自己域名绑一下这些ip就可以绕过了