### PR TITLE
OpenRasp支持BES 9.5.2代码提交

### DIFF
--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/BESDetector.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/BESDetector.java
@@ -1,0 +1,40 @@
+/**
+ *
+ */
+package com.baidu.openrasp.detector;
+
+import com.baidu.openrasp.tool.Reflection;
+import com.baidu.openrasp.tool.model.ApplicationModel;
+
+import java.security.ProtectionDomain;
+
+/**
+ * @description: BES detector
+ * @author: bes
+ * @create: 2020/03/20
+ */
+public class BESDetector extends ServerDetector {
+
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/bes/enterprise/webtier/Server".equals(className);
+    }
+
+    @Override
+    public boolean handleServerInfo(ClassLoader classLoader, ProtectionDomain domain) {
+        String version = "";
+        try {
+            if (classLoader == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            }
+            Class clazz = classLoader.loadClass("com.bes.enterprise.webtier.util.ServerInfo");
+            version = (String) Reflection.invokeMethod(null, clazz, "getServerNumber", new Class[]{});
+            ApplicationModel.setServerInfo("bes", version);
+            return true;
+        } catch (Throwable t) {
+            logDetectError("handle Tongweb startup failed", t);
+        }
+        return false;
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetector.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetector.java
@@ -108,6 +108,8 @@ public abstract class ServerDetector {
                 HookHandler.doRealCheckWithoutRequest(CheckParameter.Type.POLICY_SERVER_JBOSSEAP, CheckParameter.EMPTY_MAP);
             } else if ("tongweb".equals(serverName)) {
                 HookHandler.doRealCheckWithoutRequest(CheckParameter.Type.POLICY_SERVER_TONGWEB, CheckParameter.EMPTY_MAP);
+            } else if ("bes".equals(serverName)) {
+                HookHandler.doRealCheckWithoutRequest(CheckParameter.Type.POLICY_SERVER_BES, CheckParameter.EMPTY_MAP);
             }
         } catch (Throwable t) {
             LogTool.warn(ErrorType.HOOK_ERROR, "failed to do server policy checking: " + t.getMessage(), t);

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetectorManager.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetectorManager.java
@@ -44,6 +44,8 @@ public class ServerDetectorManager {
         detectors.add(new DubboDetector());
         detectors.add(new SpringbootDetector());
         detectors.add(new TongWebDetector());
+        detectors.add(new BESDetector());
+
     }
 
     public static ServerDetectorManager getInstance() {

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESHttpResponseHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESHttpResponseHook.java
@@ -1,0 +1,33 @@
+package com.baidu.openrasp.hook.server.bes;
+
+import com.baidu.openrasp.hook.server.ServerOutputCloseHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: BES output close hook
+ * @author: bes
+ * @create: 2020/03/20
+ */
+@HookAnnotation
+public class BESHttpResponseHook extends ServerOutputCloseHook {
+
+    public static String clazzName = null;
+
+    @Override
+    public boolean isClassMatched(String className) {
+        if ("com/bes/enterprise/webtier/connector/Response".equals(className)) {
+            clazzName = className;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "finishResponse", "()V", src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESInputBufferHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESInputBufferHook.java
@@ -1,0 +1,43 @@
+package com.baidu.openrasp.hook.server.bes;
+
+import com.baidu.openrasp.hook.server.ServerInputHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ * @description: BES input buffer hook
+ * @author: bes
+ * @create: 2020/03/20
+ */
+@HookAnnotation
+public class BESInputBufferHook extends ServerInputHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/bes/enterprise/webtier/connector/InputBuffer".equals(className);
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#hookMethod(CtClass)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String readByteSrc = getInvokeStaticSrc(ServerInputHook.class, "onInputStreamRead",
+                "$_,$0", int.class, Object.class);
+        insertAfter(ctClass, "readByte", "()I", readByteSrc);        
+        String readSrc = getInvokeStaticSrc(ServerInputHook.class, "onInputStreamRead",
+                "$_,$0,$1,$2", int.class, Object.class, byte[].class, int.class);
+        insertAfter(ctClass, "read", "([BII)I", readSrc);       
+    }
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESPreRequestHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESPreRequestHook.java
@@ -1,0 +1,37 @@
+package com.baidu.openrasp.hook.server.bes;
+
+import com.baidu.openrasp.hook.server.ServerPreRequestHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: BES pre-request hook
+ * @author: bes
+ * @create: 2020/03/20
+ */
+@HookAnnotation
+public class BESPreRequestHook extends ServerPreRequestHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("com/bes/enterprise/webtier/connector/CoyoteAdapter");
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see ServerPreRequestHook#hookMethod(CtClass, String)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "service", null, src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESRequestEndHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESRequestEndHook.java
@@ -1,0 +1,35 @@
+package com.baidu.openrasp.hook.server.bes;
+
+import com.baidu.openrasp.hook.server.ServerRequestEndHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ * @description: BES response end hook
+ * @author: bes
+ * @create: 2020/03/20
+ */
+@HookAnnotation
+public class BESRequestEndHook extends ServerRequestEndHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("com/bes/enterprise/webtier/core/ApplicationFilterChain");
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String requestEndSrc = getInvokeStaticSrc(ServerRequestEndHook.class, "checkRequestEnd", "");
+        insertAfter(ctClass, "doFilter", null, requestEndSrc, true);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESRequestHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESRequestHook.java
@@ -1,0 +1,32 @@
+package com.baidu.openrasp.hook.server.bes;
+
+import com.baidu.openrasp.hook.server.ServerParamHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: BES request hook
+ * @author: bes
+ * @create: 2020/03/20
+ */
+@HookAnnotation
+public class BESRequestHook extends ServerParamHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/bes/enterprise/webtier/connector/Request".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertAfter(ctClass, "parseParameters", "()V", src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESResponseBodyHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESResponseBodyHook.java
@@ -1,0 +1,136 @@
+/**
+ *
+ */
+package com.baidu.openrasp.hook.server.bes;
+
+import com.baidu.openrasp.HookHandler;
+import com.baidu.openrasp.hook.server.ServerResponseBodyHook;
+import com.baidu.openrasp.messaging.LogTool;
+import com.baidu.openrasp.plugin.checker.CheckParameter;
+import com.baidu.openrasp.response.HttpServletResponse;
+import com.baidu.openrasp.tool.Reflection;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import com.baidu.openrasp.tool.model.ApplicationModel;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+
+/**
+ * @description: BES response body hook
+ * @author: bes
+ * @create: 2020/03/20
+ */
+@HookAnnotation
+public class BESResponseBodyHook extends ServerResponseBodyHook {
+
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/bes/enterprise/webtier/connector/OutputBuffer".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String src1 = getInvokeStaticSrc(BESResponseBodyHook.class, "getBuffer", "$0,$1", Object.class);
+        insertBefore(ctClass, "realWriteBytes", "(Ljava/nio/ByteBuffer;)V", src1);
+    }
+
+    public static void getBuffer(Object response, Object trunk) {
+        boolean isCheckXss = isCheckXss();
+        boolean isCheckSensitive = isCheckSensitive();
+        if (HookHandler.isEnableXssHook() && (isCheckXss || isCheckSensitive) && trunk != null) {
+            HookHandler.disableBodyXssHook();
+            HashMap<String, Object> params = new HashMap<String, Object>();
+            try {
+                HttpServletResponse res = HookHandler.responseCache.get();
+                String enc = null;
+                String contentType = null;
+                if (res != null) {
+                    enc = res.getCharacterEncoding();
+                    contentType = res.getContentType();
+                }
+                if (enc != null) {
+                    params.put("buffer", trunk);
+                    params.put("content_length", Reflection.invokeMethod(response, "getContentLength", new Class[]{}));
+                    params.put("encoding", enc);
+                    params.put("content_type", contentType);
+                    if (trunk instanceof ByteBuffer) {
+                        params.put("content", getContentFromByteBuffer((ByteBuffer) trunk, enc));
+                    } else {
+                        params.put("content", getContentFromByteTrunk(trunk, enc));
+                    }
+
+                    checkBody(params, isCheckXss, isCheckSensitive);
+                }
+            } catch (Exception e) {
+                LogTool.traceHookWarn(ApplicationModel.getServerName() + " xss detectde failed: " +
+                        e.getMessage(), e);
+            } finally {
+                HookHandler.enableBodyXssHook();
+            }
+        }
+    }
+
+    private static String getContentFromByteBuffer(ByteBuffer trunk, String enc) throws UnsupportedEncodingException {
+        byte[] bytes = trunk.array();
+        int end = trunk.limit();
+        int start = trunk.position();
+        byte[] tmp = new byte[end - start];
+        System.arraycopy(bytes, start, tmp, 0, end - start);
+        return new String(tmp, enc);
+    }
+
+    private static String getContentFromByteTrunk(Object trunk, String enc) throws UnsupportedEncodingException {
+        byte[] bytes = (byte[]) Reflection.invokeMethod(trunk, "getBuffer", new Class[]{});
+        int start = (Integer) Reflection.invokeMethod(trunk, "getStart", new Class[]{});
+        int end = (Integer) Reflection.invokeMethod(trunk, "getEnd", new Class[]{});
+        byte[] tmp = new byte[end - start];
+        System.arraycopy(bytes, start, tmp, 0, end - start);
+        return new String(tmp, enc);
+    }
+
+    public static void handleXssBlockBuffer(CheckParameter parameter, String script) throws UnsupportedEncodingException {
+        Integer contentLength = (Integer) parameter.getParam("content_length");
+        Object buffer = parameter.getParam("buffer");
+        byte[] content = script.getBytes(parameter.getParam("encoding").toString());
+        if (buffer instanceof ByteBuffer) {
+            ((ByteBuffer) buffer).clear();
+        } else {
+            Reflection.invokeMethod(buffer, "recycle", new Class[]{});
+        }
+        if (contentLength != null && contentLength >= 0) {
+            byte[] fullContent = new byte[contentLength];
+            if (contentLength >= content.length) {
+                for (int i = 0; i < content.length; i++) {
+                    fullContent[i] = content[i];
+                }
+            }
+            for (int i = content.length; i < contentLength; i++) {
+                fullContent[i] = ' ';
+            }
+            writeContentToBuffer(buffer, fullContent);
+        } else {
+            writeContentToBuffer(buffer, content);
+        }
+    }
+
+    private static void writeContentToBuffer(Object buffer, byte[] content) throws UnsupportedEncodingException {
+        if (buffer instanceof ByteBuffer) {
+            ByteBuffer b = (ByteBuffer) buffer;
+            if (content.length > b.remaining() && b.remaining() > 0) {
+                b.put((byte) ' ');
+            } else {
+                b.put(content, 0, content.length);
+            }
+            b.flip();
+        } else {
+            Reflection.invokeMethod(buffer, "setBytes", new Class[]{byte[].class, int.class, int.class},
+                    content, 0, content.length);
+        }
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESwebFilterHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/bes/BESwebFilterHook.java
@@ -1,0 +1,41 @@
+package com.baidu.openrasp.hook.server.bes;
+
+import com.baidu.openrasp.hook.server.ServerRequestHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ * @description: BES ApplicationFilterChain hook
+ * @author: bes
+ * @create: 2020/03/20
+ */
+@HookAnnotation
+public class BESwebFilterHook extends ServerRequestHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("com/bes/enterprise/webtier/core/ApplicationFilterChain");
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#hookMethod(CtClass)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String src = getInvokeStaticSrc(ServerRequestHook.class, "checkRequest", "$0,$1,$2", Object.class, Object.class,
+                Object.class);
+        insertBefore(ctClass, "doFilter", null, src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/CheckParameter.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/CheckParameter.java
@@ -78,7 +78,8 @@ public class CheckParameter {
         POLICY_SERVER_WEBSPHERE("websphereServer", new WebsphereSecurityChecker(false), 0),
         POLICY_SERVER_WEBLOGIC("weblogicServer", new WeblogicSecurityChecker(false), 0),
         POLICY_SERVER_WILDFLY("wildflyServer", new WildflySecurityChecker(false), 0),
-        POLICY_SERVER_TONGWEB("tongwebServer", new TongwebSecurityChecker(false), 0);
+        POLICY_SERVER_TONGWEB("tongwebServer", new TongwebSecurityChecker(false), 0),
+        POLICY_SERVER_BES("bes", new BESSecurityChecker(false), 0);
 
         String name;
         Checker checker;

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/policy/server/BESSecurityChecker.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/policy/server/BESSecurityChecker.java
@@ -1,0 +1,29 @@
+package com.baidu.openrasp.plugin.checker.policy.server;
+
+import com.baidu.openrasp.plugin.checker.CheckParameter;
+import com.baidu.openrasp.plugin.info.EventInfo;
+
+import java.util.List;
+
+/**
+ * @description: BES security checker
+ * @author: bes
+ * @create: 2020/03/20
+ */
+public class BESSecurityChecker extends ServerPolicyChecker {
+
+    public BESSecurityChecker() {
+        super();
+    }
+
+    public BESSecurityChecker(boolean canBlock) {
+        super(canBlock);
+    }
+    
+	@Override
+	public void checkServer(CheckParameter checkParameter, List<EventInfo> infos) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/response/HttpServletResponse.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/response/HttpServletResponse.java
@@ -18,6 +18,7 @@ package com.baidu.openrasp.response;
 
 import com.baidu.openrasp.HookHandler;
 import com.baidu.openrasp.config.Config;
+import com.baidu.openrasp.hook.server.bes.BESResponseBodyHook;
 import com.baidu.openrasp.hook.server.catalina.CatalinaResponseBodyHook;
 import com.baidu.openrasp.messaging.LogTool;
 import com.baidu.openrasp.plugin.checker.CheckParameter;
@@ -183,10 +184,13 @@ public class HttpServletResponse {
                 } else {
                     script = Config.getConfig().getBlockHtml().replace(CONTENT_TYPE_REPLACE_REQUEST_ID, requestId);
                 }
-                if (parameter.getType().equals(CheckParameter.Type.XSS_USERINPUT)
-                        && "tomcat".equals(ApplicationModel.getServerName())) {
-                    CatalinaResponseBodyHook.handleXssBlockBuffer(parameter, script);
-                } else {
+                if (parameter.getType().equals(CheckParameter.Type.XSS_USERINPUT)) {
+                    if ("tomcat".equals(ApplicationModel.getServerName())) {
+                        CatalinaResponseBodyHook.handleXssBlockBuffer(parameter, script);
+                    } else if ("bes".equals(ApplicationModel.getServerName())) {
+                        BESResponseBodyHook.handleXssBlockBuffer(parameter, script);
+                    }
+                }else {
                     if (!isCommitted) {
                         resetBuffer();
                         Reflection.invokeMethod(response, "setStatus", new Class[]{int.class}, statusCode);


### PR DESCRIPTION
提交说明：基于openrasp当前master版本，提交了支持BES服务器的代码，新增9个java文件，修改4个java文件。

测试结果：针对vulns测试用例，所有测试用例均已测试通过。测试环境：CentOS 6.4 / 1.7.0_80（64位) / BES9.5.2/Chrome 74 ，rasp以单机模式运行（管理平台未测试）。

遗留说明：RaspInstall.jar 尚不支持在BES上安装rasp，这块代码未进行改造。
