### PR TITLE
增加对getMacAddress中获取mac的长度检查

### DIFF
--- a/agent/java/engine/src/main/java/com/baidu/openrasp/tool/OSUtil.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/tool/OSUtil.java
@@ -121,7 +121,7 @@ public class OSUtil {
             try {
                 if (!netInterface.isLoopback()) {
                     byte[] mac = netInterface.getHardwareAddress();
-                    if (mac == null)
+                    if (mac == null || mac.length == 0)
                         continue;
                     String macString = "";
                     for (byte b : mac) {


### PR DESCRIPTION
实测在jdk1.6.0_45+tomcat6环境中，部分网卡获取到的mac不为null，且length为空。导致StringIndexOutOfBoundsException，造成无法获取RaspId。

![报错信息](https://user-images.githubusercontent.com/11143269/112086711-b1a40000-8bc7-11eb-972d-dc5c29898a27.png)
![获取的mac长度为0](https://user-images.githubusercontent.com/11143269/112086782-d26c5580-8bc7-11eb-879a-582919eeb640.png)
