### PR TITLE
generate uuid for requestId of rmi request

### DIFF
--- a/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/info/AttackInfo.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/info/AttackInfo.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.UUID;
 
 /**
  * Created by zhuming01 on 7/11/17.
@@ -151,7 +152,10 @@ public class AttackInfo extends EventInfo {
         } else {
             info.put("source_code", "");
         }
-        if (request != null) {
+        if (request == null) {
+            // 请求ID
+            info.put("request_id", UUID.randomUUID().toString().replace("-", ""));
+        } else {
             // 请求ID
             info.put("request_id", request.getRequestId());
             // 攻击来源IP


### PR DESCRIPTION
[中文说明: 提交你的代码](https://rasp.baidu.com/doc/hacking/pull-request.html)

对于上传到服务端的Attack告警事件，每个事件需要分配一个requestId，方便计算插入的id值。
对于非HTTP请求如RMI等，由于request为NULL，所以导致数据的upsert_id相同，导致重复覆盖，所以需要随机一个请求ID给服务端