### PR TITLE
[java] 修复windows下命令执行检测的hook问题

### DIFF
--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/system/ProcessBuilderHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/system/ProcessBuilderHook.java
@@ -76,13 +76,13 @@ public class ProcessBuilderHook extends AbstractClassHook {
     @Override
     protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
         if (ctClass.getName().contains("ProcessImpl")) {
-            if (ModuleLoader.isModularityJdk()) {
+            if (OSUtil.isWindows() || !ModuleLoader.isModularityJdk()) {
                 String src = getInvokeStaticSrc(ProcessBuilderHook.class, "checkCommand",
-                        "$1,$2,$4", byte[].class, byte[].class, byte[].class);
+                        "$1,$2", String[].class, String.class);
                 insertBefore(ctClass, "<init>", null, src);
             } else {
                 String src = getInvokeStaticSrc(ProcessBuilderHook.class, "checkCommand",
-                        "$1,$2", String[].class, String.class);
+                        "$1,$2,$4", byte[].class, byte[].class, byte[].class);
                 insertBefore(ctClass, "<init>", null, src);
             }
         } else if (ctClass.getName().contains("UNIXProcess")) {

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/system/ProcessBuilderHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/system/ProcessBuilderHook.java
@@ -76,11 +76,11 @@ public class ProcessBuilderHook extends AbstractClassHook {
     @Override
     protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
         if (ctClass.getName().contains("ProcessImpl")) {
-            if (OSUtil.isWindows() || !ModuleLoader.isModularityJdk()) {
+            if (OSUtil.isWindows()) {
                 String src = getInvokeStaticSrc(ProcessBuilderHook.class, "checkCommand",
                         "$1,$2", String[].class, String.class);
                 insertBefore(ctClass, "<init>", null, src);
-            } else {
+            } else if (ModuleLoader.isModularityJdk()) {
                 String src = getInvokeStaticSrc(ProcessBuilderHook.class, "checkCommand",
                         "$1,$2,$4", byte[].class, byte[].class, byte[].class);
                 insertBefore(ctClass, "<init>", null, src);


### PR DESCRIPTION
原版的代码，windows + jdk1.7以上的环境下，无法生效。
简而言之就是hook点没有判断系统是否为windows，导致插入的代码有误。
目前看来linux和windows中jdk对ProcessImpl的实现也是不一样的，仅判断“UNIXProcess”还不够。
也就是一个小的改动。我这边简单测试了一下是没有问题的。