### PR TITLE
iast.js 构建context时，初始化bug

### DIFF
--- a/plugins/iast/plugin.js
+++ b/plugins/iast/plugin.js
@@ -159,9 +159,9 @@ function send_rasp_result(context) {
 
     // 构建 context
     var new_context             = Object.assign({}, context)
-    new_context.json            = new_context.json || {}
-    new_context.parameter       = new_context.parameter || {}
-    new_context.querystring     = new_context.querystring || ""
+    new_context.json            = context.json || {}
+    new_context.parameter       = context.parameter || {}
+    new_context.querystring     = context.querystring || ""
 
     if (context.header["scan-request-id"] === undefined) {
         new_context.body = bufferToHex(context.body).substr(0, 200)


### PR DESCRIPTION
new_context初始化的时候，用的应该是传进来的context吧，而不是刚刚创建的自己吧...