### PR TITLE
兼容适配tongweb7

### DIFF
--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetectorManager.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetectorManager.java
@@ -44,6 +44,7 @@ public class ServerDetectorManager {
         detectors.add(new DubboDetector());
         detectors.add(new SpringbootDetector());
         detectors.add(new TongWebDetector());
+        detectors.add(new TongWeb7Detector());
         detectors.add(new BESDetector());
 
     }

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/TongWeb7Detector.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/TongWeb7Detector.java
@@ -1,0 +1,31 @@
+package com.baidu.openrasp.detector;
+
+import com.baidu.openrasp.tool.Reflection;
+import com.baidu.openrasp.tool.model.ApplicationModel;
+
+import java.security.ProtectionDomain;
+
+public class TongWeb7Detector extends ServerDetector{
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/tongweb/catalina/Server".equals(className);
+    }
+
+    @Override
+    public boolean handleServerInfo(ClassLoader classLoader, ProtectionDomain domain) {
+        String version = "";
+        try {
+            if (classLoader == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            }
+            Class clazz = classLoader.loadClass("com.tongweb.catalina.util.ServerInfo");
+            version = (String) Reflection.invokeMethod(null, clazz, "getServerNumber", new Class[]{});
+            ApplicationModel.setServerInfo("tongweb", version);
+            return true;
+        } catch (Throwable t) {
+            logDetectError("handle Tongweb startup failed", t);
+        }
+        return false;
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7FilterHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7FilterHook.java
@@ -1,0 +1,41 @@
+package com.baidu.openrasp.hook.server.tongweb7;
+
+import com.baidu.openrasp.hook.server.ServerRequestHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ * @description: Tongweb ApplicationFilterChain 处理hook
+ * @author: zxl
+ * @create: 2022-01-01
+ */
+@HookAnnotation
+public class Tongweb7FilterHook extends ServerRequestHook {
+
+	/**
+	 * (none-javadoc)
+	 *
+	 * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+	 */
+	@Override
+	public boolean isClassMatched(String className) {
+		return className.endsWith("com/tongweb/catalina/core/ApplicationFilterChain");
+	}
+
+	/**
+	 * (none-javadoc)
+	 *
+	 * @see com.baidu.openrasp.hook.AbstractClassHook#hookMethod(CtClass)
+	 */
+	@Override
+	protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+		String src = getInvokeStaticSrc(ServerRequestHook.class, "checkRequest", "$0,$1,$2", Object.class, Object.class,
+				Object.class);
+		insertBefore(ctClass, "doFilter", null, src);
+	}
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7HttpResponseHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7HttpResponseHook.java
@@ -1,0 +1,33 @@
+package com.baidu.openrasp.hook.server.tongweb7;
+
+import com.baidu.openrasp.hook.server.ServerOutputCloseHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: 插入Tongweb服务器应答处理hook
+ * @author: zxl
+ * @create: 2022-01-01
+ */
+@HookAnnotation
+public class Tongweb7HttpResponseHook extends ServerOutputCloseHook {
+
+    public static String clazzName = null;
+
+	@Override
+	public boolean isClassMatched(String className) {
+        if ("com/tongweb/catalina/connector/Response".equals(className)) {
+            clazzName = className;
+            return true;
+        }
+        return false;	
+    }
+    
+	@Override
+	protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "finishResponse", "()V", src);
+	}
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7InputBufferHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7InputBufferHook.java
@@ -1,0 +1,43 @@
+package com.baidu.openrasp.hook.server.tongweb7;
+
+import com.baidu.openrasp.hook.server.ServerInputHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ * @description: 插入Tongweb获取请求body处理hook
+ * @author: zxl
+ * @create: 2022-01-01
+ */
+@HookAnnotation
+public class Tongweb7InputBufferHook extends ServerInputHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/tongweb/catalina/connector/InputBuffer".equals(className);
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#hookMethod(CtClass)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String readByteSrc = getInvokeStaticSrc(ServerInputHook.class, "onInputStreamRead",
+                "$_,$0", int.class, Object.class);
+        insertAfter(ctClass, "readByte", "()I", readByteSrc);        
+        String readSrc = getInvokeStaticSrc(ServerInputHook.class, "onInputStreamRead",
+                "$_,$0,$1,$2", int.class, Object.class, byte[].class, int.class);
+        insertAfter(ctClass, "read", "([BII)I", readSrc);       
+    }
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7PreRequestHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7PreRequestHook.java
@@ -1,0 +1,37 @@
+package com.baidu.openrasp.hook.server.tongweb7;
+
+import com.baidu.openrasp.hook.server.ServerPreRequestHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: Tongweb ServerPreRequestHook 处理hook，会执行onParseParameters 进行预处理
+ * @author: zxl
+ * @create: 2022-01-01
+ */
+@HookAnnotation
+public class Tongweb7PreRequestHook extends ServerPreRequestHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("com/tongweb/catalina/connector/CoyoteAdapter");
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see ServerPreRequestHook#hookMethod(CtClass, String)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "service", null, src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7RequestEndHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7RequestEndHook.java
@@ -1,0 +1,35 @@
+package com.baidu.openrasp.hook.server.tongweb7;
+
+import com.baidu.openrasp.hook.server.ServerRequestEndHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ *
+ *@author: zxl
+ *@create: 2022-01-01
+ */
+@HookAnnotation
+public class Tongweb7RequestEndHook extends ServerRequestEndHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("com/tongweb/catalina/core/ApplicationFilterChain");
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String requestEndSrc = getInvokeStaticSrc(ServerRequestEndHook.class, "checkRequestEnd", "");
+        insertAfter(ctClass, "doFilter", null, requestEndSrc, true);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7RequestHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7RequestHook.java
@@ -1,0 +1,32 @@
+package com.baidu.openrasp.hook.server.tongweb7;
+
+import com.baidu.openrasp.hook.server.ServerParamHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: 插入Tongweb7获取request请求处理hook
+ * @author: zxl
+ * @create: 2022-01-01
+ */
+@HookAnnotation
+public class Tongweb7RequestHook extends ServerParamHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/tongweb/coyote/Request".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "getParameters", null, src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7ResponseBodyHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/tongweb7/Tongweb7ResponseBodyHook.java
@@ -1,0 +1,65 @@
+/**
+ *
+ */
+package com.baidu.openrasp.hook.server.tongweb7;
+
+import com.baidu.openrasp.HookHandler;
+import com.baidu.openrasp.hook.server.ServerResponseBodyHook;
+import com.baidu.openrasp.messaging.LogTool;
+import com.baidu.openrasp.response.HttpServletResponse;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import com.baidu.openrasp.tool.model.ApplicationModel;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+/**
+ * @description: Tongweb body_xss hook点
+ * @author: zxl
+ * @create: 2022-01-01
+ */
+@HookAnnotation
+public class Tongweb7ResponseBodyHook extends ServerResponseBodyHook {
+
+    @Override
+    public boolean isClassMatched(String className) {
+        return "com/tongweb/catalina/connector/OutputBuffer".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String src1 = getInvokeStaticSrc(Tongweb7ResponseBodyHook.class, "getBufferFromByteArray", "$1,$2,$3", byte[].class, int.class, int.class);
+        insertBefore(ctClass, "realWriteBytes", "([BII)V", src1);
+    }
+
+    public static void getBufferFromByteArray(byte[] buf, int off, int cnt) {
+        boolean isCheckXss = isCheckXss();
+        boolean isCheckSensitive = isCheckSensitive();
+        if (HookHandler.isEnableXssHook() && (isCheckXss || isCheckSensitive)) {
+            HookHandler.disableBodyXssHook();
+            HashMap<String, Object> params = new HashMap<String, Object>();
+            if (buf != null && cnt > 0) {
+                try {
+                    byte[] temp = new byte[cnt + 1];
+                    System.arraycopy(buf, off, temp, 0, cnt);
+                    String content = new String(temp);
+                    params.put("content", content);
+                    HttpServletResponse res = HookHandler.responseCache.get();
+                    if (res != null) {
+                        params.put("content_type", res.getContentType());
+                    }
+                } catch (Exception e) {
+                    LogTool.traceHookWarn(ApplicationModel.getServerName() + " xss detectde failed: " +
+                            e.getMessage(), e);
+                }
+                if (HookHandler.requestCache.get() != null && !params.isEmpty()) {
+                    checkBody(params, isCheckXss, isCheckSensitive);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
 由于tongweb7与rasp之前适配的tongweb版本的差异较大，主要是目录结构和其他实现。因此新增对tongweb7的agent部分代码的适配。
