### PR TITLE
plugin.js修复 判断里怎么就掉了等号。。

### DIFF
--- a/plugins/official/plugin.js
+++ b/plugins/official/plugin.js
@@ -2067,7 +2067,7 @@ plugin.register('sql_exception', function(params, context) {
             }
         }
     }
-    else if (params.server = 'sqlite') {
+    else if (params.server == 'sqlite') {
         if (error_code == 1) {
             // 忽略大小写匹配
             if ( !/syntax/i.test(params.error_msg) && !  /malformed MATCH/i.test(params.error_msg)) {


### PR DESCRIPTION
[中文说明: 提交你的代码](https://rasp.baidu.com/doc/hacking/pull-request.html)

fix if(params.server = 'sqlite') =》if( params.server == 'sqlite')
