### PR TITLE
fix: err is shadowed

### DIFF
--- a/cloud/src/rasp-cloud/es/es.go
+++ b/cloud/src/rasp-cloud/es/es.go
@@ -223,7 +223,8 @@ func BulkInsertAlarm(docType string, docs []map[string]interface{}) (err error) 
 	}
 
 	if response.Errors {
-		errContent, err := json.Marshal(response.Failed())
+		var errContent []byte
+		errContent, err = json.Marshal(response.Failed())
 		if err == nil {
 			err = errors.New("ES bulk has errors: " + string(errContent))
 		}


### PR DESCRIPTION
The err is shadowed if response.Errors is true, the err returned will be nil.
