### PR TITLE
fix nits: error message format

### DIFF
--- a/cloud/src/rasp-cloud/es/es.go
+++ b/cloud/src/rasp-cloud/es/es.go
@@ -287,7 +287,7 @@ func UpdateMapping(destIndex string, alias string, template string, ctx context.
 	}
 
 	if len(res.IndicesByAlias(alias)) == 0 {
-		return errors.New("alias: " + alias + "is not exist!")
+		return fmt.Errorf("alias: %s is not exist", alias)
 	}
 	if len(res.IndicesByAlias(alias)) > 2 {
 		return errors.New("find duplicate alias:" + fmt.Sprintf("%s", res.IndicesByAlias(alias)))

--- a/cloud/src/rasp-cloud/es/es.go
+++ b/cloud/src/rasp-cloud/es/es.go
@@ -287,7 +287,7 @@ func UpdateMapping(destIndex string, alias string, template string, ctx context.
 	}
 
 	if len(res.IndicesByAlias(alias)) == 0 {
-		return errors.New("alias:" + fmt.Sprintf("%s", res) + "is not exist!")
+		return errors.New("alias: " + alias + "is not exist!")
 	}
 	if len(res.IndicesByAlias(alias)) > 2 {
 		return errors.New("find duplicate alias:" + fmt.Sprintf("%s", res.IndicesByAlias(alias)))


### PR DESCRIPTION
这里`res`是结构体，所以如果格式化应该使用%v：`fmt.Sprintf("%v", res)`。不过从程序上来看这里错误信息应该是返回不存在的alias就可以了。
