### PR TITLE
[后台] 修复使用换行符传递参数，不能正确转为数组的bug

### DIFF
--- a/rasp-vue/src/util/index.js
+++ b/rasp-vue/src/util/index.js
@@ -150,17 +150,10 @@ export var status_types = {
   // ignore: '忽略放行'
 }
 
-// 去除空格、换行，按照指定的分隔符分隔，最后删掉 null/undefined/空字符串
-// 去除空格、换行，按照指定的分隔符分隔，最后删掉 null/undefined/空字符串
+// 按照指定的分隔符分隔，最后删掉 null/undefined/空字符串
 export function trimSplit(data, sep) {
-  let tmp
-  if (sep === '\n') { // 对于使用换行符进行分割的字符串，需要先 split，再去除空格
-    tmp = data.split(sep).map(i => i.replace(/\s/g, ''))
-  } else {
-    tmp = data.replace(/\s/g, '').split(sep)
-  }
-
-  return tmp.filter(a => a)
+  let tmp = data.split(sep)
+  return tmp.filter(a => a.trim())
 }
 
 export function convertToInt(data) {

--- a/rasp-vue/src/util/index.js
+++ b/rasp-vue/src/util/index.js
@@ -151,8 +151,15 @@ export var status_types = {
 }
 
 // 去除空格、换行，按照指定的分隔符分隔，最后删掉 null/undefined/空字符串
+// 去除空格、换行，按照指定的分隔符分隔，最后删掉 null/undefined/空字符串
 export function trimSplit(data, sep) {
-  var tmp = data.replace(/\s/g, '').split(sep)
+  let tmp
+  if (sep === '\n') { // 对于使用换行符进行分割的字符串，需要先 split，再去除空格
+    tmp = data.split(sep).map(i => i.replace(/\s/g, ''))
+  } else {
+    tmp = data.replace(/\s/g, '').split(sep)
+  }
+
   return tmp.filter(a => a)
 }
 
@@ -182,7 +189,7 @@ export function getDefaultConfig() {
       recv_addr: []
     },
     kafka_alarm_conf: {
-      
+
     },
     general_alarm_conf: {
 


### PR DESCRIPTION
[中文说明: 提交你的代码](https://rasp.baidu.com/doc/hacking/pull-request.html)

**问题**

在后台管理中，涉及到 `textarea` 尝尽时，是根据用户输入的换行进行分割。在此场景下，如果分隔符是换行（`\n`），会导致配置失效。

**问题复现**

点击修改 _反序列化黑名单（一行一个）_
<img width="595" alt="image" src="https://user-images.githubusercontent.com/9459488/157191971-f86e7a13-d24f-4577-b7e2-40e6e8a1405e.png">
点击确定后，再打开
<img width="595" alt="image" src="https://user-images.githubusercontent.com/9459488/157192120-60083e84-6ab6-466c-8eba-3f4240e05f04.png">


**修复**

对以换行符分割的字符串进行额外处理。先分割，再进行空格去除处理。

---

**修复后的效果展示**

_（提交前）输入测试字符串_
<img width="591" alt="image" src="https://user-images.githubusercontent.com/9459488/157192690-68da02b7-877f-4b16-bc7b-546cea8e232f.png">

_（提交后）再次打开，得到处理后效果_
<img width="575" alt="image" src="https://user-images.githubusercontent.com/9459488/157192923-b3d41884-f371-492f-89f8-1aa1821036f0.png">


