### PR TITLE
OpenRASP支持InforSuiteASV10.0

### DIFF
--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/InforSuiteASDetector.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/InforSuiteASDetector.java
@@ -1,0 +1,40 @@
+/**
+ *
+ */
+package com.baidu.openrasp.detector;
+
+import com.baidu.openrasp.tool.Reflection;
+import com.baidu.openrasp.tool.model.ApplicationModel;
+
+import java.security.ProtectionDomain;
+
+/**
+ * @description: InforSuiteAS detector
+ * @author: codff
+ * @create: 2022/3/17
+ */
+public class InforSuiteASDetector extends ServerDetector {
+
+    @Override
+    public boolean isClassMatched(String className) {
+        return "org/apache/catalina/Server".equals(className);
+    }
+
+    @Override
+    public boolean handleServerInfo(ClassLoader classLoader, ProtectionDomain domain) {
+        String version = "";
+        try {
+            if (classLoader == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            }
+            Class clazz = classLoader.loadClass("org.apache.catalina.util.ServerInfo");
+            version = (String) Reflection.invokeMethod(null, clazz, "getServerNumber", new Class[]{});
+            ApplicationModel.setServerInfo("inforsuiteas", version);
+            return true;
+        } catch (Throwable t) {
+            logDetectError("handle inforsuiteas startup failed", t);
+        }
+        return false;
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetector.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetector.java
@@ -111,6 +111,11 @@ public abstract class ServerDetector {
             } else if ("bes".equals(serverName)) {
                 HookHandler.doRealCheckWithoutRequest(CheckParameter.Type.POLICY_SERVER_BES, CheckParameter.EMPTY_MAP);
             }
+            // add by codff start
+            else if ("inforsuiteas".equals(serverName)) {
+                HookHandler.doRealCheckWithoutRequest(CheckParameter.Type.POLICY_SERVER_INFORSUITEAS, CheckParameter.EMPTY_MAP);
+            }
+            // add by codff end
         } catch (Throwable t) {
             LogTool.warn(ErrorType.HOOK_ERROR, "failed to do server policy checking: " + t.getMessage(), t);
         }

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetectorManager.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/detector/ServerDetectorManager.java
@@ -46,7 +46,9 @@ public class ServerDetectorManager {
         detectors.add(new TongWebDetector());
         detectors.add(new TongWeb7Detector());
         detectors.add(new BESDetector());
-
+        // add by codff start
+        detectors.add(new InforSuiteASDetector());
+        // add by codff end
     }
 
     public static ServerDetectorManager getInstance() {

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASApplicationFilterHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASApplicationFilterHook.java
@@ -1,0 +1,41 @@
+package com.baidu.openrasp.hook.server.inforsuiteas;
+
+import com.baidu.openrasp.hook.server.ServerRequestHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ * @description: InforSuiteAS ApplicationFilter Hook
+ * @author: codff
+ * @create: 2022/03/17
+ */
+@HookAnnotation
+public class InforSuiteASApplicationFilterHook extends ServerRequestHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("org/apache/catalina/core/ApplicationFilterChain");
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#hookMethod(CtClass)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String src = getInvokeStaticSrc(ServerRequestHook.class, "checkRequest",
+                "$0,$1,$2", Object.class, Object.class, Object.class);
+        insertBefore(ctClass, "doFilter", null, src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASCoyoteAdapterHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASCoyoteAdapterHook.java
@@ -1,0 +1,41 @@
+package com.baidu.openrasp.hook.server.inforsuiteas;
+
+import com.baidu.openrasp.hook.server.ServerPreRequestHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: InforSuiteAS CoyoteAdapter Hook
+ * @author: codff
+ * @create: 2022/03/17
+ */
+@HookAnnotation
+public class InforSuiteASCoyoteAdapterHook extends ServerPreRequestHook {
+
+    public InforSuiteASCoyoteAdapterHook() {
+        couldIgnore = false;
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("org/apache/catalina/connector/CoyoteAdapter");
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see ServerPreRequestHook#hookMethod(CtClass, String)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "service", null, src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASHttpInputHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASHttpInputHook.java
@@ -1,0 +1,64 @@
+package com.baidu.openrasp.hook.server.inforsuiteas;
+
+import com.baidu.openrasp.hook.server.ServerInputHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ * @description: InforSuiteAS HttpInput Hook
+ * @author: codff
+ * @create: 2022/03/17
+ */
+@HookAnnotation
+public class InforSuiteASHttpInputHook extends ServerInputHook {
+
+    private String className;
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        if( "org/apache/catalina/connector/InputBuffer".equals(className)
+                || "org/apache/catalina/connector/CoyoteReader".equals(className)){
+            this.className=className;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#hookMethod(CtClass)
+     */
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        if(className.equals("org/apache/catalina/connector/InputBuffer")){
+            String readByteSrc = getInvokeStaticSrc(ServerInputHook.class, "onInputStreamRead",
+                    "$_,$0", int.class, Object.class);
+            insertAfter(ctClass, "readByte", "()I", readByteSrc);
+            String readSrc = getInvokeStaticSrc(ServerInputHook.class, "onInputStreamRead",
+                    "$_,$0,$1,$2", int.class, Object.class, byte[].class, int.class);
+            insertAfter(ctClass, "read", "([BII)I", readSrc);
+
+        }else {
+            String src = getInvokeStaticSrc(ServerInputHook.class, "onCharRead", "$_,$0", int.class, Object.class);
+            insertAfter(ctClass, "read", "()I", src);
+            src = getInvokeStaticSrc(ServerInputHook.class, "onCharRead",
+                    "$_,$0,$1", int.class, Object.class, char[].class);
+            insertAfter(ctClass, "read", "([C)I", src);
+
+            src = getInvokeStaticSrc(ServerInputHook.class, "onCharRead",
+                    "$_,$0,$1,$2", int.class, Object.class, char[].class, int.class);
+            insertAfter(ctClass, "read", "([CII)I", src);
+        }
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASOutputBufferHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASOutputBufferHook.java
@@ -1,0 +1,34 @@
+package com.baidu.openrasp.hook.server.inforsuiteas;
+
+import com.baidu.openrasp.hook.server.ServerOutputCloseHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: InforSuiteAS OutputBuffer Hook
+ * @author: codff
+ * @create: 2022/03/17
+ */
+@HookAnnotation
+public class InforSuiteASOutputBufferHook extends ServerOutputCloseHook {
+
+        public static String clazzName = null;
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "org/apache/catalina/connector/OutputBuffer".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertBefore(ctClass, "close", "()V", src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASRequestEndHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASRequestEndHook.java
@@ -1,0 +1,35 @@
+package com.baidu.openrasp.hook.server.inforsuiteas;
+
+import com.baidu.openrasp.hook.server.ServerRequestEndHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+
+/**
+ * @description: InforSuiteAS RequestEnd Hook
+ * @author: codff
+ * @create: 2022/03/17
+ */
+@HookAnnotation
+public class InforSuiteASRequestEndHook extends ServerRequestEndHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return className.endsWith("org/apache/catalina/core/ApplicationFilterChain");
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String requestEndSrc = getInvokeStaticSrc(ServerRequestEndHook.class, "checkRequestEnd", "");
+        insertAfter(ctClass, "doFilter", null, requestEndSrc, true);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASRequestHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASRequestHook.java
@@ -1,0 +1,32 @@
+package com.baidu.openrasp.hook.server.inforsuiteas;
+
+import com.baidu.openrasp.hook.server.ServerParamHook;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+/**
+ * @description: InforSuiteAS Request Hook
+ * @author: codff
+ * @create: 2022/03/17
+ */
+@HookAnnotation
+public class InforSuiteASRequestHook extends ServerParamHook {
+
+    /**
+     * (none-javadoc)
+     *
+     * @see com.baidu.openrasp.hook.AbstractClassHook#isClassMatched(String)
+     */
+    @Override
+    public boolean isClassMatched(String className) {
+        return "org/apache/catalina/connector/Request".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass, String src) throws NotFoundException, CannotCompileException {
+        insertAfter(ctClass, "parseParameters", "()V", src);
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASResponseBodyHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/server/inforsuiteas/InforSuiteASResponseBodyHook.java
@@ -1,0 +1,136 @@
+package com.baidu.openrasp.hook.server.inforsuiteas;
+
+import com.baidu.openrasp.HookHandler;
+import com.baidu.openrasp.hook.server.ServerResponseBodyHook;
+import com.baidu.openrasp.hook.server.bes.BESResponseBodyHook;
+import com.baidu.openrasp.hook.server.catalina.CatalinaResponseBodyHook;
+import com.baidu.openrasp.hook.server.tongweb.TongwebResponseBodyHook;
+import com.baidu.openrasp.messaging.LogTool;
+import com.baidu.openrasp.plugin.checker.CheckParameter;
+import com.baidu.openrasp.response.HttpServletResponse;
+import com.baidu.openrasp.tool.Reflection;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import com.baidu.openrasp.tool.model.ApplicationModel;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+
+/**
+ * @description: InforSuiteAS ServerResponseBody Hook
+ * @author: codff
+ * @create: 2022/03/17
+ */
+@HookAnnotation
+public class InforSuiteASResponseBodyHook extends ServerResponseBodyHook {
+
+    @Override
+    public boolean isClassMatched(String className) {
+        return "org/apache/catalina/connector/OutputBuffer".equals(className);
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String src1 = getInvokeStaticSrc(BESResponseBodyHook.class, "getBuffer", "$0,$1", Object.class, Object.class);
+        insertBefore(ctClass, "realWriteBytes", "(Ljava/nio/ByteBuffer;)V", src1);
+    }
+
+    public static void getBuffer(Object response, Object trunk) {
+        boolean isCheckXss = isCheckXss();
+        boolean isCheckSensitive = isCheckSensitive();
+        if (HookHandler.isEnableXssHook() && (isCheckXss || isCheckSensitive) && trunk != null) {
+            HookHandler.disableBodyXssHook();
+            HashMap<String, Object> params = new HashMap<String, Object>();
+            try {
+                HttpServletResponse res = HookHandler.responseCache.get();
+                String enc = null;
+                String contentType = null;
+                if (res != null) {
+                    enc = res.getCharacterEncoding();
+                    contentType = res.getContentType();
+                }
+                if (enc != null) {
+                    params.put("buffer", trunk);
+                    params.put("content_length", Reflection.invokeMethod(response, "getContentLength", new Class[]{}));
+                    params.put("encoding", enc);
+                    params.put("content_type", contentType);
+                    if (trunk instanceof ByteBuffer) {
+                        params.put("content", getContentFromByteBuffer((ByteBuffer) trunk, enc));
+                    } else {
+                        params.put("content", getContentFromByteTrunk(trunk, enc));
+                    }
+
+                    checkBody(params, isCheckXss, isCheckSensitive);
+                }
+            } catch (Exception e) {
+                LogTool.traceHookWarn(ApplicationModel.getServerName() + " xss detection failed: " +
+                        e.getMessage(), e);
+            } finally {
+                HookHandler.enableBodyXssHook();
+            }
+        }
+    }
+
+    private static String getContentFromByteBuffer(ByteBuffer trunk, String enc) throws UnsupportedEncodingException {
+        byte[] bytes = trunk.array();
+        int end = trunk.limit();
+        int start = trunk.position();
+        byte[] tmp = new byte[end - start];
+        System.arraycopy(bytes, start, tmp, 0, end - start);
+        return new String(tmp, enc);
+    }
+
+    private static String getContentFromByteTrunk(Object trunk, String enc) throws UnsupportedEncodingException {
+        byte[] bytes = (byte[]) Reflection.invokeMethod(trunk, "getBuffer", new Class[]{});
+        int start = (Integer) Reflection.invokeMethod(trunk, "getStart", new Class[]{});
+        int end = (Integer) Reflection.invokeMethod(trunk, "getEnd", new Class[]{});
+        byte[] tmp = new byte[end - start];
+        System.arraycopy(bytes, start, tmp, 0, end - start);
+        return new String(tmp, enc);
+    }
+
+    public static void handleXssBlockBuffer(CheckParameter parameter, String script) throws UnsupportedEncodingException {
+        Integer contentLength = (Integer) parameter.getParam("content_length");
+        Object buffer = parameter.getParam("buffer");
+        byte[] content = script.getBytes(parameter.getParam("encoding").toString());
+        if (buffer instanceof ByteBuffer) {
+            ((ByteBuffer) buffer).clear();
+        } else {
+            Reflection.invokeMethod(buffer, "recycle", new Class[]{});
+        }
+        if (contentLength != null && contentLength >= 0) {
+            byte[] fullContent = new byte[contentLength];
+            if (contentLength >= content.length) {
+                for (int i = 0; i < content.length; i++) {
+                    fullContent[i] = content[i];
+                }
+            }
+            for (int i = content.length; i < contentLength; i++) {
+                fullContent[i] = ' ';
+            }
+            writeContentToBuffer(buffer, fullContent);
+        } else {
+            writeContentToBuffer(buffer, content);
+        }
+    }
+
+    private static void writeContentToBuffer(Object buffer, byte[] content) throws UnsupportedEncodingException {
+        if (buffer instanceof ByteBuffer) {
+            ByteBuffer b = (ByteBuffer) buffer;
+            if (content.length > b.remaining() && b.remaining() > 0) {
+                b.put((byte) ' ');
+            } else {
+                b.put(content, 0, content.length);
+            }
+            b.flip();
+        } else {
+            Reflection.invokeMethod(buffer, "setBytes", new Class[]{byte[].class, int.class, int.class},
+                    content, 0, content.length);
+        }
+    }
+
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/CheckParameter.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/CheckParameter.java
@@ -83,8 +83,10 @@ public class CheckParameter {
         POLICY_SERVER_WEBLOGIC("weblogicServer", new WeblogicSecurityChecker(false), 0),
         POLICY_SERVER_WILDFLY("wildflyServer", new WildflySecurityChecker(false), 0),
         POLICY_SERVER_TONGWEB("tongwebServer", new TongwebSecurityChecker(false), 0),
-        POLICY_SERVER_BES("bes", new BESSecurityChecker(false), 0);
-
+        POLICY_SERVER_BES("bes", new BESSecurityChecker(false), 0),
+        // add by codff start
+        POLICY_SERVER_INFORSUITEAS("inforsuiteas", new InforSuiteASSecurityChecker(false), 0);
+        // add by codff end
         String name;
         Checker checker;
         Integer code;

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/policy/server/InforSuiteASSecurityChecker.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/policy/server/InforSuiteASSecurityChecker.java
@@ -1,0 +1,27 @@
+package com.baidu.openrasp.plugin.checker.policy.server;
+
+import com.baidu.openrasp.plugin.checker.CheckParameter;
+import com.baidu.openrasp.plugin.info.EventInfo;
+import java.util.List;
+
+/**
+ * @description: InforSuiteAS ServerPolicyChecker
+ * @author: codff
+ * @create: 2022/03/17
+ */
+public class InforSuiteASSecurityChecker extends ServerPolicyChecker {
+
+    public InforSuiteASSecurityChecker() {
+        super();
+    }
+
+    public InforSuiteASSecurityChecker(boolean canBlock) {
+        super(canBlock);
+    }
+
+    @Override
+    public void checkServer(CheckParameter checkParameter, List<EventInfo> infos) {
+        // TODO Auto-generated method stub
+
+    }
+}

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/response/HttpServletResponse.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/response/HttpServletResponse.java
@@ -20,6 +20,7 @@ import com.baidu.openrasp.HookHandler;
 import com.baidu.openrasp.config.Config;
 import com.baidu.openrasp.hook.server.bes.BESResponseBodyHook;
 import com.baidu.openrasp.hook.server.catalina.CatalinaResponseBodyHook;
+import com.baidu.openrasp.hook.server.inforsuiteas.InforSuiteASResponseBodyHook;
 import com.baidu.openrasp.hook.server.tongweb7.Tongweb7ResponseBodyHook;
 import com.baidu.openrasp.messaging.LogTool;
 import com.baidu.openrasp.plugin.checker.CheckParameter;
@@ -192,6 +193,11 @@ public class HttpServletResponse {
                         BESResponseBodyHook.handleXssBlockBuffer(parameter, script);
                     } else if("tongweb".equals(ApplicationModel.getServerName())){
                         Tongweb7ResponseBodyHook.handleXssBlockBuffer(parameter, script);
+                    }
+                    // add by codff start
+                    else if("iforsuiteas".equals(ApplicationModel.getServerName())){
+                        InforSuiteASResponseBodyHook.handleXssBlockBuffer(parameter, script);
+                        // add by codff end
                     }
                 }else {
                     if (!isCommitted) {


### PR DESCRIPTION
提交说明：基于openrasp当前1.3.8版本，提交了支持InforSuiteAS服务器的代码，新增9个java文件，修改4个java文件。

测试结果：针对vulns测试用例，所有测试用例均已测试通过。测试环境：CentOS 7 / 1.8.0_322（64位) / InforSuite ASV10.0/Firefox，rasp以单机模式运行（管理平台未测试）。

遗留说明：RaspInstall.jar 尚不支持在InforSuiteAS上安装rasp，这块代码未进行改造。
