### PR TITLE
[java] XssChecker新增LCS检测策略

### DIFF
--- a/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/local/ConfigurableChecker.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/plugin/checker/local/ConfigurableChecker.java
@@ -101,6 +101,18 @@ public abstract class ConfigurableChecker extends AttackChecker {
         return null;
     }
 
+    public static boolean getBooleanElement(JsonObject config, String key, String subKey) {
+        try {
+            JsonElement value = getElement(config, key, subKey);
+            if (value != null) {
+                return value.getAsBoolean();
+            }
+        } catch (Exception e) {
+            logJsonError(e);
+        }
+        return false;
+    }
+
     public static JsonElement getElement(JsonObject config, String key, String subKey) {
         if (config != null) {
             JsonElement jsonElement = config.get(key);


### PR DESCRIPTION
开启研发模式时用最长公共字符串算法来判断响应是否受输入参数影响，LCS 长度大于 DEFAULT_MIN_LENGTH 则判断存在漏洞；没有开启研发模式的话和之前一样直接用 contains 比较。

fix #170