### PR TITLE
检测算法改进：无法正确过滤content-type

### DIFF
--- a/plugins/official/plugin.js
+++ b/plugins/official/plugin.js
@@ -3189,7 +3189,7 @@ if (algorithmConfig.response_dataLeak.action != 'ignore') {
         var items = [], parts = []
 
         // content-type 过滤
-        if ( ! content_type && ! dataLeakContentType.test(content_type)) {
+        if ( ! content_type || ! dataLeakContentType.test(content_type)) {
             return clean
         }
 


### PR DESCRIPTION
当前敏感信息的逻辑错误，无法过滤非html、json、xml的response
应该把逻辑与改为逻辑或

逻辑与的问题：content-type为application/javascript时，无法直接return clean
我们预想的结果应该是：正则匹配失败时return clean，正则匹配成功不return clean