### PR TITLE
[死锁导致应用启动异常 #435]前置获取PID，解决死锁导致启动异常的问题 + [agent]增加通过springboot内置的文件上传hook点。

### DIFF
--- a/agent/java/boot/src/main/java/com/baidu/openrasp/Agent.java
+++ b/agent/java/boot/src/main/java/com/baidu/openrasp/Agent.java
@@ -17,10 +17,10 @@
 package com.baidu.openrasp;
 
 import org.apache.commons.cli.*;
-// import sun.management.FileSystem;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
+import java.lang.management.ManagementFactory;
 import java.net.URL;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -37,6 +37,7 @@ public class Agent {
     public static String projectVersion;
     public static String buildTime;
     public static String gitCommit;
+    public static int pid;
 
     public static void main(String[] args) {
         try {
@@ -112,6 +113,14 @@ public class Agent {
         projectVersion = (projectVersion == null ? "UNKNOWN" : projectVersion);
         buildTime = (buildTime == null ? "UNKNOWN" : buildTime);
         gitCommit = (gitCommit == null ? "UNKNOWN" : gitCommit);
+
+        // [死锁导致应用启动异常 #435]前置获取PID，解决死锁导致启动异常的问题
+        try {
+            pid = Integer.parseInt(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]);
+        } catch (Throwable e) {
+            pid = -1;
+        }
+
     }
 
 }

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/cloud/httpappender/HttpAppender.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/cloud/httpappender/HttpAppender.java
@@ -16,6 +16,7 @@
 
 package com.baidu.openrasp.cloud.httpappender;
 
+import com.baidu.openrasp.Agent;
 import com.baidu.openrasp.cloud.CloudHttp;
 import com.baidu.openrasp.cloud.ThreadPool;
 import com.baidu.openrasp.cloud.model.AppenderCache;
@@ -33,7 +34,6 @@ import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.ThrowableInformation;
 
-import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -168,17 +168,8 @@ public class HttpAppender extends AppenderSkeleton {
         ThrowableInformation information = loggingEvent.getThrowableInformation();
         Throwable t = information != null ? information.getThrowable() : null;
         StackTraceElement[] traceElements = t != null ? t.getStackTrace() : new StackTraceElement[]{};
-        ExceptInfo info = new ExceptInfo(level, message, errorCode, getProcessID(), traceElements);
+        ExceptInfo info = new ExceptInfo(level, message, errorCode, Agent.pid, traceElements);
         return new Gson().toJson(info.getInfo());
-    }
-
-    private int getProcessID() {
-        try {
-            String[] pids = ManagementFactory.getRuntimeMXBean().getName().split("@");
-            return Integer.parseInt(pids[0]);
-        } catch (Throwable e) {
-            return -1;
-        }
     }
 
     @Override

--- a/agent/java/engine/src/main/java/com/baidu/openrasp/hook/file/FileUploadSpringframeworkHook.java
+++ b/agent/java/engine/src/main/java/com/baidu/openrasp/hook/file/FileUploadSpringframeworkHook.java
@@ -1,0 +1,54 @@
+package com.baidu.openrasp.hook.file;
+
+import com.baidu.openrasp.HookHandler;
+import com.baidu.openrasp.hook.AbstractClassHook;
+import com.baidu.openrasp.plugin.checker.CheckParameter;
+import com.baidu.openrasp.tool.annotation.HookAnnotation;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+/**
+ * springboot框架文件上传hook点
+ * <p>
+ * 参考FileUploadItemHook
+ *
+ * @author jinlong-ghq
+ */
+@HookAnnotation
+public class FileUploadSpringframeworkHook extends AbstractClassHook {
+
+    @Override
+    public boolean isClassMatched(String className) {
+        return "org/springframework/web/multipart/support/StandardMultipartHttpServletRequest$StandardMultipartFile".equals(className);
+    }
+
+    @Override
+    public String getType() {
+        return "fileUpload";
+    }
+
+    @Override
+    protected void hookMethod(CtClass ctClass) throws IOException, CannotCompileException, NotFoundException {
+        String src = getInvokeStaticSrc(FileUploadSpringframeworkHook.class,
+                "checkFileItemWithBytes", "$1", File.class);
+        insertBefore(ctClass, "transferTo", "(Ljava/io/File;)V", src);
+
+    }
+
+    /**
+     * 检查文件项（带字节）
+     *
+     * @param dest 文件
+     */
+    public static void checkFileItemWithBytes(File dest) {
+        HashMap<String, Object> params = new HashMap<String, Object>();
+        params.put("filename", dest.getName());
+        HookHandler.doCheck(CheckParameter.Type.FILEUPLOAD, params);
+    }
+
+}


### PR DESCRIPTION
死锁导致应用启动异常 #435