### PR TITLE
修复RASP PHP Agent在宝塔PHP环境的安装BUG

### DIFF
--- a/rasp-install/php/install.php
+++ b/rasp-install/php/install.php
@@ -657,6 +657,13 @@ if (extension_loaded('openrasp') && array_key_exists("keep-ini", $options)) {
 				array_push($ini_files_2b_updated, $wamp_apache_ini);
 			}
 		}
+		$first_ini_file_path = $ini_files_2b_updated[0];
+		$file_name = basename($first_ini_file_path);
+		$dir_name = dirname($first_ini_file_path);
+		$php_ini_file_path = $dir_name . DIRECTORY_SEPARATOR . 'php.ini';
+		if ($file_name != 'php.ini' && file_exists($php_ini_file_path)) {
+			array_push($ini_files_2b_updated, $php_ini_file_path);
+		}
 		foreach ($ini_files_2b_updated as $key => $ini_file) {
 			if (!is_writable($ini_file)) {
 				log_tips(ERROR, $ini_file . ' is not writable, make sure you have write permissions');


### PR DESCRIPTION

修复RASP PHP Agent在宝塔PHP环境的安装BUG

## 问题描述

原始的install.php脚本在宝塔PHP环境的时候，把OpenRASP的ini配置写入了错误的php.ini文件中。宝塔安装的PHP有一个php-cli.ini， install.php把配置写入了cli中，导致OpenRASP的配置不生效，OpenRASP的管理后端看不到宿主机Agent上报的心跳。在列表中没有显示。

## 解决方案

检测php-cli.ini同级目录有没有php.ini存在，如果存在，再把同样的配置写入php.ini中

## 运行截图:

![image](https://github.com/baidu/openrasp/assets/8574915/420d4324-f008-4d91-bb9c-a4c0e35c17ad)

![image](https://github.com/baidu/openrasp/assets/8574915/2ecb8639-fdac-4ee4-bd5d-43b2342a0693)


由上图得知，在宝塔安装的PHP环境中，RASP的配置最开始写入php-cli.ini中了，导致RASP配置不生效。

